### PR TITLE
Increase tool call read timeout 30s -> 120s and add exponential backo…

### DIFF
--- a/services/mcp_eval/mcp_completion/config.py
+++ b/services/mcp_eval/mcp_completion/config.py
@@ -24,7 +24,7 @@ class Config:
 
     # Timeout configuration
     DEFAULT_TIMEOUT: float = float(os.getenv("DEFAULT_TIMEOUT", "300.0"))
-    TOOL_CALL_TIMEOUT: float = float(os.getenv("TOOL_CALL_TIMEOUT", "30.0"))
+    TOOL_CALL_TIMEOUT: float = float(os.getenv("TOOL_CALL_TIMEOUT", "120.0"))
     LIST_TOOLS_TIMEOUT: float = float(os.getenv("LIST_TOOLS_TIMEOUT", "120.0"))
 
     # Logging configuration

--- a/services/mcp_eval/mcp_completion_script.py
+++ b/services/mcp_eval/mcp_completion_script.py
@@ -236,7 +236,10 @@ class AsyncMCPTrajectoryGenerator:
                 logging.error(f"Error on attempt {attempt + 1}/{MAX_RETRY_ATTEMPTS} for task {taskId}: {e}")
                 
             if attempt < MAX_RETRY_ATTEMPTS - 1:
-                await asyncio.sleep(10)
+                base_delay = min(10 * (2 ** attempt), 60)
+                delay = random.uniform(0, base_delay)  # Full jitter (AWS recommended)
+                logging.info(f"Retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRY_ATTEMPTS})")
+                await asyncio.sleep(delay)
         
         return None, MAX_RETRY_ATTEMPTS
 


### PR DESCRIPTION
I ran the MCP atlas eval like so:

```
uv run python mcp_completion_script.py \
  --model "openai/gpt-4o" \
  --input_huggingface "bhertz/mcp_dummy" \  # TODO switch to dataset on ScaleAI
  --output "mcp_eval_4o_results.csv"
```

and experienced many MCP read timeouts https://pastebin.com/z6MH1K1E . 

The current behavior does a 10s delay prior to retry causing possible thundering herd behavior. This can be partially mitigated using exponential backoff + jitter. I also increased the read timeout from 30s to 120s since I still saw some MCP tools consistently timeout (e.g. OSM); this is likely due to these tools simply having a larger response time.

After this change I found that nearly all read timeouts were mitigated; less than a handful occurring afterwards. I still think there is room to improve by having a granular tool-dependent timeout (e.g. some tools take longer than others and thus should have larger timeouts).