### PR TITLE
Fix structured output format and temperature handling for OpenAI evaluator models

### DIFF
--- a/services/mcp_eval/mcp_evals_scores.py
+++ b/services/mcp_eval/mcp_evals_scores.py
@@ -45,6 +45,7 @@ nest_asyncio.apply()
 
 # Configure LiteLLM - suppress verbose logging
 litellm.set_verbose = False
+litellm.drop_params = True
 logging.getLogger("LiteLLM").setLevel(logging.WARNING)
 
 
@@ -360,26 +361,46 @@ class AsyncLiteLLMClient(AsyncLLMClient):
             try:
                 self.request_count += 1
 
-                # LiteLLM uses OpenAI-compatible format
-                # Pass response_schema for structured output (Gemini supports this natively)
-                response = await litellm.acompletion(
-                    model=self.config.evaluator_model,
-                    messages=[{"role": "user", "content": prompt}],
-                    response_format={
+                # Build response_format based on provider
+                model_name = self.config.evaluator_model.lower()
+                is_openai = model_name.startswith("openai/") or model_name.startswith("gpt-")
+                _REASONING_PREFIXES = ("o1", "o3", "o4", "gpt-5")
+                bare_name = model_name.removeprefix("openai/")
+                is_reasoning = any(bare_name.startswith(p) for p in _REASONING_PREFIXES)
+
+                if is_openai:
+                    fmt = {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "evaluation",
+                            "schema": {
+                                **response_schema,
+                                "additionalProperties": False,
+                            },
+                            "strict": True,
+                        },
+                    }
+                else:
+                    fmt = {
                         "type": "json_object",
                         "response_schema": response_schema,
-                    },
-                    temperature=(
-                        1 if self.config.evaluator_model == "gpt-5" else temperature
-                    ),  # gpt-5 only supports temperature=1
-                    api_key=litellm.api_key,
-                    api_base=(
+                    }
+
+                kwargs: Dict = {
+                    "model": self.config.evaluator_model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "response_format": fmt,
+                    "api_key": litellm.api_key,
+                    "api_base": (
                         litellm.api_base
                         if hasattr(litellm, "api_base") and litellm.api_base
                         else None
                     ),
-                )
+                }
+                if not is_reasoning:
+                    kwargs["temperature"] = temperature
 
+                response = await litellm.acompletion(**kwargs)
                 # Rate limiting delay
                 await asyncio.sleep(self.config.request_delay)
 

--- a/services/mcp_eval/mcp_evals_scores.py
+++ b/services/mcp_eval/mcp_evals_scores.py
@@ -363,7 +363,7 @@ class AsyncLiteLLMClient(AsyncLLMClient):
 
                 # Build response_format based on provider
                 model_name = self.config.evaluator_model.lower()
-                is_openai = model_name.startswith("openai/") or model_name.startswith("gpt-")
+                is_openai = model_name.startswith(("openai/", "gpt-", "o1", "o3", "o4"))
                 _REASONING_PREFIXES = ("o1", "o3", "o4", "gpt-5")
                 bare_name = model_name.removeprefix("openai/")
                 is_reasoning = any(bare_name.startswith(p) for p in _REASONING_PREFIXES)


### PR DESCRIPTION
## Summary

When using an OpenAI model (e.g. `openai/gpt-5.1`) as the evaluator via `--evaluator-model`, the scoring script fails with:

```
litellm.BadRequestError: OpenAIException - Unknown parameter: 'response_format.response_schema'
```

This happens because `response_schema` inside `response_format` is a Gemini-specific parameter that the OpenAI API does not recognize.

This PR fixes the issue by:

- **Provider-aware `response_format`**: Uses OpenAI's native `json_schema` structured output format (with `strict: true`) for OpenAI models, and preserves the existing `json_object` + `response_schema` format for Gemini and other providers.
- **Proper temperature handling for reasoning models**: Instead of hard-coding `temperature=1` only for `gpt-5`, the `temperature` parameter is now omitted entirely for all OpenAI reasoning model families (`o1`, `o3`, `o4`, `gpt-5*`), since these models reject any explicit temperature value.
- **Enable `litellm.drop_params = True`**: Acts as a safety net so that any unsupported parameters are silently dropped rather than causing request failures.

## Reproduction

```bash
uv run mcp_evals_scores.py \
  --input-file="completion_results/sample_51_results.csv" \
  --evaluator-model="openai/gpt-5.1" \
  --model-label="gpt51"
```

Before this fix, every scoring request fails immediately. After this fix, OpenAI models work correctly as evaluators.

## Test plan

- [x] Verified `openai/gpt-5.1` as evaluator no longer produces `BadRequestError`
- [x] Verified Gemini models (`gemini/gemini-2.5-pro`) still work as before (no behavior change)
- [x] Confirmed `litellm.drop_params = True` is set as a fallback safety net