### PR TITLE
feat(mcp_eval): Harbor bundle validation harness (static + e2e, RL + Advanced)

### DIFF
--- a/services/mcp_eval/harbor_smoke.py
+++ b/services/mcp_eval/harbor_smoke.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""End-to-end smoke test for Harbor task bundles (Tier-2/3 pre-delivery gate).
+
+Runs a *sample* of bundles through real Harbor under one or more conditions and
+asserts each trial produced a valid reward — i.e. the environment builds, the
+healthcheck passes, the verifier runs, and **Harbor ingests the reward without a
+schema error or exception**. This is the live counterpart to
+``validate_harbor_bundles.py`` (which is static); use both before a delivery.
+
+A "condition" is a (Harbor binary, agent) pair. Pass each repeatably to cover the
+combinations that matter — at minimum the latest **json-first** Harbor, which is
+what surfaces the reward.json schema bug:
+
+    # cheap: every sampled bundle on latest Harbor with the nop agent
+    python harbor_smoke.py OUT/ --sample 5 \\
+        --harbor ~/harbor-smoke/venv_013/bin/harbor --agent nop
+
+    # belt-and-suspenders: also a pinned (txt-first) Harbor, and a real agent
+    python harbor_smoke.py OUT/ --sample 5 \\
+        --harbor ~/harbor-smoke/venv_013/bin/harbor \\
+        --harbor ~/harbor-smoke/venv_0145/bin/harbor \\
+        --agent nop --agent claude-code -m claude-sonnet-4-6
+
+The same sampled bundles are reused across every condition (comparability).
+Requires Docker + the bundles' images reachable, and the LLM auth env vars
+(ANTHROPIC_*/LITELLM_*) exported for the verifier (and for a real agent).
+
+`nop` exercises env build + healthcheck + verifier + Harbor's reward read with no
+LLM cost (the judge fast-fails on the missing trajectory and writes reward 0.0);
+`claude-code` additionally exercises the success-path reward write.
+
+A PASS = the trial's result.json has a non-null ``verifier_result`` with a numeric
+``reward`` in [0, 1] and ``exception_info == null``. Exit code is non-zero if any
+(bundle, condition) cell fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _iter_bundles(root: Path):
+    if (root / "task.toml").is_file():
+        yield root
+        return
+    for child in sorted(p for p in root.iterdir() if p.is_dir()):
+        if (child / "task.toml").is_file():
+            yield child
+
+
+def _find_trial_result(out_dir: Path) -> dict | None:
+    """Return the trial-level result.json (the one with verifier_result/exception_info)."""
+    best = None
+    for rj in out_dir.rglob("result.json"):
+        try:
+            data = json.loads(rj.read_text())
+        except Exception:  # noqa: BLE001
+            continue
+        if isinstance(data, dict) and ("verifier_result" in data or "exception_info" in data):
+            best = data  # prefer the deepest/last (trial-level) over job-level
+    return best
+
+
+def _verdict(result: dict | None) -> tuple[bool, str]:
+    if result is None:
+        return False, "no trial result.json produced"
+    exc = result.get("exception_info")
+    if exc:
+        etype = exc.get("exception_type") if isinstance(exc, dict) else exc
+        return False, f"exception: {etype}"
+    vr = result.get("verifier_result")
+    if not vr or not isinstance(vr, dict):
+        return False, "verifier_result is null/empty"
+    rewards = vr.get("rewards")
+    if not isinstance(rewards, dict) or "reward" not in rewards:
+        return False, f"no scalar 'reward' in verifier_result.rewards ({rewards!r})"
+    val = rewards["reward"]
+    if not isinstance(val, (int, float)) or not (0.0 <= float(val) <= 1.0):
+        return False, f"reward out of range/!numeric: {val!r}"
+    return True, f"reward={val}"
+
+
+def run_one(harbor: str, agent: str, model: str, bundle: Path, out_root: Path) -> tuple[bool, str]:
+    out = out_root / f"{bundle.name}__{Path(harbor).parent.parent.name}__{agent}"
+    out.mkdir(parents=True, exist_ok=True)
+    cmd = [harbor, "run", "-p", str(bundle), "-a", agent, "-k", "1", "-n", "1", "-y", "-o", str(out)]
+    if model:
+        cmd += ["-m", model]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    result = _find_trial_result(out)
+    ok, detail = _verdict(result)
+    if not ok and result is None and proc.returncode != 0:
+        # surface the harbor error tail when nothing was produced
+        tail = (proc.stderr or proc.stdout).strip().splitlines()[-1:] or [""]
+        detail = f"{detail} | harbor: {tail[0][:120]}"
+    return ok, detail
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("path", type=Path, help="A bundle dir, or a parent dir of bundles")
+    p.add_argument("--harbor", action="append", required=True, metavar="HARBOR_BIN",
+                   help="Path to a harbor binary (repeat for multiple versions)")
+    p.add_argument("--agent", action="append", required=True, metavar="AGENT",
+                   help="Agent name, e.g. nop or claude-code (repeat for multiple)")
+    p.add_argument("-m", "--model", default="", help="Model for the agent (e.g. claude-sonnet-4-6)")
+    p.add_argument("--sample", type=int, default=3, help="Number of bundles to sample (0 = all)")
+    p.add_argument("--seed", type=int, default=0, help="Sampling seed (for a reproducible sample)")
+    p.add_argument("--out", type=Path, default=None, help="Output dir for harbor runs (default: temp)")
+    args = p.parse_args()
+
+    bundles = list(_iter_bundles(args.path))
+    if not bundles:
+        print(f"error: no bundles under {args.path}", file=sys.stderr)
+        return 2
+    random.seed(args.seed)
+    if args.sample and args.sample < len(bundles):
+        bundles = random.sample(bundles, args.sample)
+    bundles.sort(key=lambda b: b.name)
+
+    out_root = args.out or Path(tempfile.mkdtemp(prefix="harbor_smoke_"))
+    conditions = [(h, a) for h in args.harbor for a in args.agent]
+    print(f"Smoke: {len(bundles)} bundle(s) x {len(conditions)} condition(s)  ->  out={out_root}\n")
+
+    failures = 0
+    for bundle in bundles:
+        print(f"== {bundle.name} ==")
+        for harbor, agent in conditions:
+            ver = Path(harbor).parent.parent.name  # e.g. venv_013
+            ok, detail = run_one(harbor, agent, args.model, bundle, out_root)
+            print(f"   [{ver} / {agent}] {'PASS' if ok else 'FAIL'} — {detail}")
+            if not ok:
+                failures += 1
+        print()
+
+    total = len(bundles) * len(conditions)
+    print(f"{total - failures}/{total} (bundle x condition) cells passed", file=sys.stderr)
+    if failures:
+        print(f"RESULT: FAILED ({failures} cell(s))", file=sys.stderr)
+        return 1
+    print("RESULT: PASSED", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/mcp_eval/validate_harbor_bundles.py
+++ b/services/mcp_eval/validate_harbor_bundles.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Validate Harbor task bundles before delivery (deterministic; no Docker/LLM).
+
+Checks each bundle directory — the output of ``convert_tasks_to_harbor.py``, or
+any Harbor task bundle — against the structural and verifier contracts Harbor
+relies on, so format regressions are caught here instead of at run time (or by a
+customer). It is stdlib-only so it runs anywhere, including CI.
+
+Per bundle (``<task_id>/``):
+  * required files are present
+  * ``task.toml`` parses and has the required keys (needs Python 3.11+ ``tomllib``
+    or ``tomli``; otherwise the TOML-structural checks are skipped with a note)
+  * ``environment/enabled_tools.txt`` matches ``task.toml``'s ``enabled_tools``
+  * ``tests/test.sh`` and ``solution/solve.sh`` are executable and start with a
+    ``#!`` shebang
+  * ``tests/agent_judge.py``:
+      - compiles
+      - its module body imports/execs cleanly — catches the JSON-literal
+        ``NameError`` class (e.g. ``CRITERIA``/``OUTPUT_SCHEMA`` embedded via
+        ``json.dumps`` so ``true``/``false``/``null`` become undefined names)
+      - defines a non-empty list ``CRITERIA``, a dict ``OUTPUT_SCHEMA``, and a
+        callable ``aggregate_score``
+      - ``aggregate_score``: full pass -> 1.0, incomplete / empty -> 0.0
+      - the ``reward.json`` it writes is a flat scalar dict — Harbor parses it
+        into ``VerifierResult(rewards: dict[str, float | int])``, so a list/dict
+        value breaks verification. AST-checked here; cross-checked against
+        Harbor's real model when ``--harbor-check`` is given.
+
+Exit code is non-zero if any bundle fails.
+
+Usage:
+  python validate_harbor_bundles.py OUT/                 # every bundle under OUT/
+  python validate_harbor_bundles.py OUT/<task_id>        # a single bundle
+  python validate_harbor_bundles.py OUT/ --harbor-check  # also import harbor + check
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - environment dependent
+    try:
+        import tomli as tomllib  # type: ignore
+    except ModuleNotFoundError:
+        tomllib = None  # type: ignore
+
+REQUIRED_FILES = [
+    "task.toml",
+    "instruction.md",
+    "environment/Dockerfile",
+    "environment/enabled_tools.txt",
+    "tests/test.sh",
+    "tests/agent_judge.py",
+    "solution/solve.sh",
+]
+EXECUTABLE_SCRIPTS = ["tests/test.sh", "solution/solve.sh"]
+REWARD_JSON_PATH = "/logs/verifier/reward.json"
+
+
+def _check_files(bundle: Path) -> list[str]:
+    problems = []
+    for rel in REQUIRED_FILES:
+        if not (bundle / rel).is_file():
+            problems.append(f"missing file: {rel}")
+    if (bundle / "instruction.md").is_file() and not (bundle / "instruction.md").read_text(encoding="utf-8").strip():
+        problems.append("instruction.md is empty")
+    return problems
+
+
+def _check_scripts_executable(bundle: Path) -> list[str]:
+    problems = []
+    for rel in EXECUTABLE_SCRIPTS:
+        f = bundle / rel
+        if not f.is_file():
+            continue
+        if not (f.stat().st_mode & 0o111):
+            problems.append(f"{rel} is not executable (mode {oct(f.stat().st_mode & 0o777)})")
+        if not f.read_text(encoding="utf-8").startswith("#!"):
+            problems.append(f"{rel} has no shebang")
+    return problems
+
+
+def _check_task_toml(bundle: Path) -> list[str]:
+    f = bundle / "task.toml"
+    if not f.is_file():
+        return []  # already reported by _check_files
+    if tomllib is None:
+        return ["(task.toml structural checks skipped: no tomllib/tomli available)"]
+    try:
+        data = tomllib.loads(f.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        return [f"task.toml does not parse: {type(e).__name__}: {str(e).splitlines()[0]}"]
+    problems = []
+    meta = data.get("metadata", {})
+    if not meta.get("task_id"):
+        problems.append("task.toml: [metadata].task_id missing/empty")
+    env = data.get("environment", {})
+    servers = env.get("mcp_servers") or []
+    if not servers:
+        problems.append("task.toml: no [[environment.mcp_servers]] entry")
+    if "verifier" not in data:
+        problems.append("task.toml: no [verifier] section")
+    # enabled_tools.txt must match the task.toml allowlist (the file is what the
+    # image actually enforces; drift means the two disagree about scope).
+    toml_tools = servers[0].get("enabled_tools", []) if servers else []
+    et_file = bundle / "environment" / "enabled_tools.txt"
+    if et_file.is_file():
+        file_tools = [ln for ln in et_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        if file_tools != list(toml_tools):
+            problems.append("enabled_tools.txt does not match task.toml [[environment.mcp_servers]].enabled_tools")
+    return problems
+
+
+def _exec_judge(src: str) -> dict:
+    """Exec the generated judge's module body in a throwaway namespace.
+
+    __name__ is set so the `if __name__ == "__main__"` guard does not run
+    run_judge (which would need claude-agent-sdk / a live trajectory). os.environ
+    is saved/restored because the script mutates it at import time.
+    """
+    ns: dict = {"__name__": "_harbor_bundle_validate"}
+    saved = dict(os.environ)
+    try:
+        exec(compile(src, "<agent_judge>", "exec"), ns)
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+    return ns
+
+
+_CONTAINER_LITERALS = (ast.List, ast.Dict, ast.Set, ast.Tuple,
+                       ast.ListComp, ast.DictComp, ast.SetComp)
+_CONTAINER_METHODS = {"append", "extend", "insert", "update", "add"}
+
+
+def _container_names(tree: ast.AST) -> set[str]:
+    """Names bound to a container anywhere in the module.
+
+    Covers both ``x = [...]`` / ``x = {...}`` (and comprehensions) and names
+    that are grown via ``x.append(...)`` / ``x.update(...)`` etc. Lets the
+    reward.json check flag a value like ``verified_results`` (a list variable),
+    not just inline container literals.
+    """
+    names: set[str] = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Assign) and isinstance(n.value, _CONTAINER_LITERALS):
+            for tgt in n.targets:
+                if isinstance(tgt, ast.Name):
+                    names.add(tgt.id)
+        if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                and n.func.attr in _CONTAINER_METHODS
+                and isinstance(n.func.value, ast.Name)):
+            names.add(n.func.value.id)
+    return names
+
+
+def _reward_json_violations(src: str) -> list[str]:
+    """AST-check that agent_judge.py writes reward.json as a flat scalar dict."""
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as e:
+        return [f"agent_judge.py does not parse: {e}"]
+    container_names = _container_names(tree)
+    problems = []
+    found = False
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "write_text" and node.args):
+            continue
+        recv = node.func.value
+        if not (isinstance(recv, ast.Call) and isinstance(recv.func, ast.Name)
+                and recv.func.id == "Path" and recv.args
+                and isinstance(recv.args[0], ast.Constant)
+                and recv.args[0].value == REWARD_JSON_PATH):
+            continue
+        found = True
+        arg = node.args[0]
+        if not (isinstance(arg, ast.Call) and isinstance(arg.func, ast.Attribute)
+                and arg.func.attr == "dumps" and arg.args):
+            problems.append("reward.json write_text arg is not json.dumps(...)")
+            continue
+        payload = arg.args[0]
+        if not isinstance(payload, ast.Dict):
+            problems.append("reward.json payload is not a dict literal")
+            continue
+        for k, v in zip(payload.keys, payload.values):
+            key = ast.literal_eval(k) if isinstance(k, ast.Constant) else "<expr>"
+            if isinstance(v, _CONTAINER_LITERALS):
+                problems.append(f"reward.json key {key!r} has a non-scalar ({type(v).__name__}) value")
+            elif isinstance(v, ast.Name) and v.id in container_names:
+                problems.append(f"reward.json key {key!r} is bound to a container variable ({v.id!r}); "
+                                "Harbor requires scalar reward values")
+    if not found:
+        problems.append(f"no write to {REWARD_JSON_PATH} found in agent_judge.py")
+    return problems
+
+
+def _check_agent_judge(bundle: Path, harbor_check: bool) -> list[str]:
+    f = bundle / "tests" / "agent_judge.py"
+    if not f.is_file():
+        return []
+    src = f.read_text(encoding="utf-8")
+    problems = list(_reward_json_violations(src))
+    try:
+        ns = _exec_judge(src)
+    except Exception as e:  # noqa: BLE001 - any import/NameError here is a real defect
+        problems.append(f"agent_judge.py module body fails to exec: {type(e).__name__}: {e}")
+        return problems
+    crit = ns.get("CRITERIA")
+    if not isinstance(crit, list):
+        problems.append("agent_judge.py: CRITERIA is not a list")
+    elif not crit:
+        problems.append("agent_judge.py: CRITERIA is empty (task can never pass)")
+    if not isinstance(ns.get("OUTPUT_SCHEMA"), dict):
+        problems.append("agent_judge.py: OUTPUT_SCHEMA is not a dict")
+    agg = ns.get("aggregate_score")
+    if not callable(agg):
+        problems.append("agent_judge.py: aggregate_score is not callable")
+    elif isinstance(crit, list) and crit:
+        n = len(crit)
+        full = [{"score": 1.0}] * n
+        if agg(full) != 1.0:
+            problems.append("aggregate_score: a full pass did not score 1.0")
+        if agg(full[:-1]) != 0.0:
+            problems.append("aggregate_score: an incomplete result set did not score 0.0")
+        if agg([]) != 0.0:
+            problems.append("aggregate_score: an empty result set did not score 0.0")
+        if harbor_check:
+            problems.extend(_harbor_verifier_check(agg(full)))
+    return problems
+
+
+def _harbor_verifier_check(reward_value) -> list[str]:
+    """Cross-check the emitted reward against Harbor's real VerifierResult."""
+    try:
+        from harbor.models.verifier.result import VerifierResult
+    except Exception as e:  # noqa: BLE001
+        return [f"(--harbor-check skipped: harbor not importable: {e})"]
+    try:
+        VerifierResult(rewards={"reward": reward_value})
+    except Exception as e:  # noqa: BLE001
+        return [f"reward {{'reward': {reward_value!r}}} rejected by Harbor VerifierResult: {e}"]
+    return []
+
+
+def validate_bundle(bundle: Path, harbor_check: bool = False) -> list[str]:
+    problems = _check_files(bundle)
+    problems += _check_scripts_executable(bundle)
+    problems += _check_task_toml(bundle)
+    problems += _check_agent_judge(bundle, harbor_check)
+    # Notes (parenthesised) are informational, not failures.
+    return problems
+
+
+def _iter_bundles(root: Path):
+    """A bundle is a dir containing task.toml. Accept a single bundle or a parent."""
+    if (root / "task.toml").is_file():
+        yield root
+        return
+    for child in sorted(p for p in root.iterdir() if p.is_dir()):
+        if (child / "task.toml").is_file():
+            yield child
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("path", type=Path, help="A bundle dir, or a parent dir of bundles")
+    p.add_argument("--harbor-check", action="store_true",
+                   help="Also validate the reward against Harbor's real VerifierResult (needs harbor installed)")
+    args = p.parse_args()
+
+    if not args.path.exists():
+        print(f"error: path not found: {args.path}", file=sys.stderr)
+        return 2
+    bundles = list(_iter_bundles(args.path))
+    if not bundles:
+        print(f"error: no bundles (dirs with task.toml) found under {args.path}", file=sys.stderr)
+        return 2
+
+    failed = 0
+    for bundle in bundles:
+        problems = validate_bundle(bundle, harbor_check=args.harbor_check)
+        hard = [p for p in problems if not p.startswith("(")]
+        notes = [p for p in problems if p.startswith("(")]
+        if hard:
+            failed += 1
+            print(f"FAIL {bundle.name}")
+            for pr in hard:
+                print(f"      - {pr}")
+        else:
+            suffix = f"  {notes[0]}" if notes else ""
+            print(f"ok   {bundle.name}{suffix}")
+
+    print(f"\n{len(bundles) - failed}/{len(bundles)} bundles valid", file=sys.stderr)
+    if failed:
+        print(f"RESULT: FAILED ({failed} bundle(s) with problems)", file=sys.stderr)
+        return 1
+    print("RESULT: PASSED", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/mcp_eval/validate_harbor_bundles.py
+++ b/services/mcp_eval/validate_harbor_bundles.py
@@ -1,32 +1,32 @@
 #!/usr/bin/env python3
 """Validate Harbor task bundles before delivery (deterministic; no Docker/LLM).
 
-Checks each bundle directory — the output of ``convert_tasks_to_harbor.py``, or
-any Harbor task bundle — against the structural and verifier contracts Harbor
+Checks each bundle directory against the structural and verifier contracts Harbor
 relies on, so format regressions are caught here instead of at run time (or by a
-customer). It is stdlib-only so it runs anywhere, including CI.
+customer). Stdlib-only, so it runs anywhere — including CI.
 
-Per bundle (``<task_id>/``):
-  * required files are present
-  * ``task.toml`` parses and has the required keys (needs Python 3.11+ ``tomllib``
-    or ``tomli``; otherwise the TOML-structural checks are skipped with a note)
-  * ``environment/enabled_tools.txt`` matches ``task.toml``'s ``enabled_tools``
-  * ``tests/test.sh`` and ``solution/solve.sh`` are executable and start with a
-    ``#!`` shebang
-  * ``tests/agent_judge.py``:
-      - compiles
-      - its module body imports/execs cleanly — catches the JSON-literal
-        ``NameError`` class (e.g. ``CRITERIA``/``OUTPUT_SCHEMA`` embedded via
-        ``json.dumps`` so ``true``/``false``/``null`` become undefined names)
-      - defines a non-empty list ``CRITERIA``, a dict ``OUTPUT_SCHEMA``, and a
-        callable ``aggregate_score``
-      - ``aggregate_score``: full pass -> 1.0, incomplete / empty -> 0.0
-      - the ``reward.json`` it writes is a flat scalar dict — Harbor parses it
-        into ``VerifierResult(rewards: dict[str, float | int])``, so a list/dict
-        value breaks verification. AST-checked here; cross-checked against
-        Harbor's real model when ``--harbor-check`` is given.
+It understands two bundle shapes and applies the right structural checks to each:
 
-Exit code is non-zero if any bundle fails.
+  * **rl**       — single MCP server image: ``environment/Dockerfile`` (``FROM
+                   <image>``) + ``environment/enabled_tools.txt``; one
+                   ``[[environment.mcp_servers]]`` named ``mcp-server``.
+  * **advanced** — multi-service gateway: ``environment/docker-compose.yaml``
+                   (+ a ``Dockerfile`` for the ``main`` service); a ``gateway``
+                   mcp_server.
+
+The **verifier checks are shared** (both shapes embed the same LLM-as-judge):
+
+  * ``tests/agent_judge.py`` compiles and its module body execs cleanly — catches
+    the JSON-literal ``NameError`` class (``CRITERIA``/``OUTPUT_SCHEMA`` embedded
+    via ``json.dumps`` so ``true``/``false``/``null`` become undefined names);
+  * it defines a non-empty list ``CRITERIA``, a dict ``OUTPUT_SCHEMA``, a callable
+    ``aggregate_score`` (full pass -> 1.0, incomplete / empty -> 0.0);
+  * the ``reward.json`` it writes is a **flat scalar dict** — Harbor parses it into
+    ``VerifierResult(rewards: dict[str, float | int])``, so a list/dict value (even
+    via a variable like ``verified_results``) breaks verification. AST + light
+    dataflow; ``--harbor-check`` also validates against Harbor's real model.
+
+Errors fail the bundle (non-zero exit); warnings are reported but don't fail.
 
 Usage:
   python validate_harbor_bundles.py OUT/                 # every bundle under OUT/
@@ -50,89 +50,98 @@ except ModuleNotFoundError:  # pragma: no cover - environment dependent
     except ModuleNotFoundError:
         tomllib = None  # type: ignore
 
-REQUIRED_FILES = [
+# Files every bundle must have, regardless of shape.
+COMMON_REQUIRED = [
     "task.toml",
     "instruction.md",
     "environment/Dockerfile",
-    "environment/enabled_tools.txt",
     "tests/test.sh",
     "tests/agent_judge.py",
-    "solution/solve.sh",
 ]
 EXECUTABLE_SCRIPTS = ["tests/test.sh", "solution/solve.sh"]
 REWARD_JSON_PATH = "/logs/verifier/reward.json"
 
 
-def _check_files(bundle: Path) -> list[str]:
-    problems = []
-    for rel in REQUIRED_FILES:
+class Report:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+    def err(self, m: str) -> None:
+        self.errors.append(m)
+
+    def warn(self, m: str) -> None:
+        self.warnings.append(m)
+
+
+def _detect_shape(bundle: Path) -> str:
+    if (bundle / "environment" / "docker-compose.yaml").is_file():
+        return "advanced"
+    if (bundle / "environment" / "enabled_tools.txt").is_file():
+        return "rl"
+    return "unknown"
+
+
+def _check_files(bundle: Path, shape: str, r: Report) -> None:
+    required = list(COMMON_REQUIRED)
+    if shape == "rl":
+        required.append("environment/enabled_tools.txt")
+    elif shape == "advanced":
+        required.append("environment/docker-compose.yaml")
+    for rel in required:
         if not (bundle / rel).is_file():
-            problems.append(f"missing file: {rel}")
-    if (bundle / "instruction.md").is_file() and not (bundle / "instruction.md").read_text(encoding="utf-8").strip():
-        problems.append("instruction.md is empty")
-    return problems
+            r.err(f"missing file: {rel}")
+    inst = bundle / "instruction.md"
+    if inst.is_file() and not inst.read_text(encoding="utf-8").strip():
+        r.err("instruction.md is empty")
+    # solution/ is optional in Harbor; note if absent, don't fail.
+    if not (bundle / "solution" / "solve.sh").is_file():
+        r.warn("no solution/solve.sh (optional, but most bundles ship a stub)")
 
 
-def _check_scripts_executable(bundle: Path) -> list[str]:
-    problems = []
+def _check_scripts(bundle: Path, r: Report) -> None:
     for rel in EXECUTABLE_SCRIPTS:
         f = bundle / rel
         if not f.is_file():
             continue
+        text = f.read_text(encoding="utf-8")
+        if not text.startswith("#!"):
+            r.err(f"{rel} has no shebang (Harbor execs it directly)")
+        # Harbor chmods +x before exec, so a missing exec bit is a warning, not a failure.
         if not (f.stat().st_mode & 0o111):
-            problems.append(f"{rel} is not executable (mode {oct(f.stat().st_mode & 0o777)})")
-        if not f.read_text(encoding="utf-8").startswith("#!"):
-            problems.append(f"{rel} has no shebang")
-    return problems
+            r.warn(f"{rel} is not executable (mode {oct(f.stat().st_mode & 0o777)}); Harbor chmods it, but +x is cleaner")
 
 
-def _check_task_toml(bundle: Path) -> list[str]:
+def _check_task_toml(bundle: Path, shape: str, r: Report) -> None:
     f = bundle / "task.toml"
     if not f.is_file():
-        return []  # already reported by _check_files
+        return
     if tomllib is None:
-        return ["(task.toml structural checks skipped: no tomllib/tomli available)"]
+        r.warn("task.toml structural checks skipped: no tomllib/tomli available (need Python 3.11+)")
+        return
     try:
         data = tomllib.loads(f.read_text(encoding="utf-8"))
     except Exception as e:  # noqa: BLE001
-        return [f"task.toml does not parse: {type(e).__name__}: {str(e).splitlines()[0]}"]
-    problems = []
-    meta = data.get("metadata", {})
-    if not meta.get("task_id"):
-        problems.append("task.toml: [metadata].task_id missing/empty")
+        r.err(f"task.toml does not parse: {type(e).__name__}: {str(e).splitlines()[0]}")
+        return
+    if "verifier" not in data:
+        r.err("task.toml: no [verifier] section")
     env = data.get("environment", {})
     servers = env.get("mcp_servers") or []
     if not servers:
-        problems.append("task.toml: no [[environment.mcp_servers]] entry")
-    if "verifier" not in data:
-        problems.append("task.toml: no [verifier] section")
-    # enabled_tools.txt must match the task.toml allowlist (the file is what the
-    # image actually enforces; drift means the two disagree about scope).
-    toml_tools = servers[0].get("enabled_tools", []) if servers else []
-    et_file = bundle / "environment" / "enabled_tools.txt"
-    if et_file.is_file():
-        file_tools = [ln for ln in et_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
-        if file_tools != list(toml_tools):
-            problems.append("enabled_tools.txt does not match task.toml [[environment.mcp_servers]].enabled_tools")
-    return problems
+        r.err("task.toml: no [[environment.mcp_servers]] entry")
+    if shape == "rl":
+        if not data.get("metadata", {}).get("task_id"):
+            r.err("task.toml: [metadata].task_id missing/empty")
+        toml_tools = servers[0].get("enabled_tools", []) if servers else []
+        et_file = bundle / "environment" / "enabled_tools.txt"
+        if et_file.is_file():
+            file_tools = [ln for ln in et_file.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            if file_tools != list(toml_tools):
+                r.err("enabled_tools.txt does not match task.toml [[environment.mcp_servers]].enabled_tools")
 
 
-def _exec_judge(src: str) -> dict:
-    """Exec the generated judge's module body in a throwaway namespace.
-
-    __name__ is set so the `if __name__ == "__main__"` guard does not run
-    run_judge (which would need claude-agent-sdk / a live trajectory). os.environ
-    is saved/restored because the script mutates it at import time.
-    """
-    ns: dict = {"__name__": "_harbor_bundle_validate"}
-    saved = dict(os.environ)
-    try:
-        exec(compile(src, "<agent_judge>", "exec"), ns)
-    finally:
-        os.environ.clear()
-        os.environ.update(saved)
-    return ns
-
+# ── shared agent_judge.py checks ──────────────────────────────────────────────
 
 _CONTAINER_LITERALS = (ast.List, ast.Dict, ast.Set, ast.Tuple,
                        ast.ListComp, ast.DictComp, ast.SetComp)
@@ -140,13 +149,9 @@ _CONTAINER_METHODS = {"append", "extend", "insert", "update", "add"}
 
 
 def _container_names(tree: ast.AST) -> set[str]:
-    """Names bound to a container anywhere in the module.
-
-    Covers both ``x = [...]`` / ``x = {...}`` (and comprehensions) and names
-    that are grown via ``x.append(...)`` / ``x.update(...)`` etc. Lets the
-    reward.json check flag a value like ``verified_results`` (a list variable),
-    not just inline container literals.
-    """
+    """Names bound to a container anywhere in the module (literal assignment or
+    grown via .append/.update/etc.) — so a reward value like ``verified_results``
+    (a list variable) is flagged, not just inline container literals."""
     names: set[str] = set()
     for n in ast.walk(tree):
         if isinstance(n, ast.Assign) and isinstance(n.value, _CONTAINER_LITERALS):
@@ -161,13 +166,12 @@ def _container_names(tree: ast.AST) -> set[str]:
 
 
 def _reward_json_violations(src: str) -> list[str]:
-    """AST-check that agent_judge.py writes reward.json as a flat scalar dict."""
     try:
         tree = ast.parse(src)
     except SyntaxError as e:
         return [f"agent_judge.py does not parse: {e}"]
     container_names = _container_names(tree)
-    problems = []
+    problems: list[str] = []
     found = False
     for node in ast.walk(tree):
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
@@ -201,43 +205,18 @@ def _reward_json_violations(src: str) -> list[str]:
     return problems
 
 
-def _check_agent_judge(bundle: Path, harbor_check: bool) -> list[str]:
-    f = bundle / "tests" / "agent_judge.py"
-    if not f.is_file():
-        return []
-    src = f.read_text(encoding="utf-8")
-    problems = list(_reward_json_violations(src))
+def _exec_judge(src: str) -> dict:
+    ns: dict = {"__name__": "_harbor_bundle_validate"}
+    saved = dict(os.environ)
     try:
-        ns = _exec_judge(src)
-    except Exception as e:  # noqa: BLE001 - any import/NameError here is a real defect
-        problems.append(f"agent_judge.py module body fails to exec: {type(e).__name__}: {e}")
-        return problems
-    crit = ns.get("CRITERIA")
-    if not isinstance(crit, list):
-        problems.append("agent_judge.py: CRITERIA is not a list")
-    elif not crit:
-        problems.append("agent_judge.py: CRITERIA is empty (task can never pass)")
-    if not isinstance(ns.get("OUTPUT_SCHEMA"), dict):
-        problems.append("agent_judge.py: OUTPUT_SCHEMA is not a dict")
-    agg = ns.get("aggregate_score")
-    if not callable(agg):
-        problems.append("agent_judge.py: aggregate_score is not callable")
-    elif isinstance(crit, list) and crit:
-        n = len(crit)
-        full = [{"score": 1.0}] * n
-        if agg(full) != 1.0:
-            problems.append("aggregate_score: a full pass did not score 1.0")
-        if agg(full[:-1]) != 0.0:
-            problems.append("aggregate_score: an incomplete result set did not score 0.0")
-        if agg([]) != 0.0:
-            problems.append("aggregate_score: an empty result set did not score 0.0")
-        if harbor_check:
-            problems.extend(_harbor_verifier_check(agg(full)))
-    return problems
+        exec(compile(src, "<agent_judge>", "exec"), ns)
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+    return ns
 
 
 def _harbor_verifier_check(reward_value) -> list[str]:
-    """Cross-check the emitted reward against Harbor's real VerifierResult."""
     try:
         from harbor.models.verifier.result import VerifierResult
     except Exception as e:  # noqa: BLE001
@@ -249,17 +228,56 @@ def _harbor_verifier_check(reward_value) -> list[str]:
     return []
 
 
-def validate_bundle(bundle: Path, harbor_check: bool = False) -> list[str]:
-    problems = _check_files(bundle)
-    problems += _check_scripts_executable(bundle)
-    problems += _check_task_toml(bundle)
-    problems += _check_agent_judge(bundle, harbor_check)
-    # Notes (parenthesised) are informational, not failures.
-    return problems
+def _check_agent_judge(bundle: Path, harbor_check: bool, r: Report) -> None:
+    f = bundle / "tests" / "agent_judge.py"
+    if not f.is_file():
+        return
+    src = f.read_text(encoding="utf-8")
+    for p in _reward_json_violations(src):
+        (r.warn if p.startswith("(") else r.err)(p)
+    try:
+        ns = _exec_judge(src)
+    except Exception as e:  # noqa: BLE001 - any import/NameError here is a real defect
+        r.err(f"agent_judge.py module body fails to exec: {type(e).__name__}: {e}")
+        return
+    crit = ns.get("CRITERIA")
+    if not isinstance(crit, list):
+        r.err("agent_judge.py: CRITERIA is not a list")
+    elif not crit:
+        r.err("agent_judge.py: CRITERIA is empty (task can never pass)")
+    if not isinstance(ns.get("OUTPUT_SCHEMA"), dict):
+        r.err("agent_judge.py: OUTPUT_SCHEMA is not a dict")
+    agg = ns.get("aggregate_score")
+    if not callable(agg):
+        r.err("agent_judge.py: aggregate_score is not callable")
+    elif isinstance(crit, list) and crit:
+        n = len(crit)
+        full = [{"score": 1.0}] * n
+        if agg(full) != 1.0:
+            r.err("aggregate_score: a full pass did not score 1.0")
+        if agg(full[:-1]) != 0.0:
+            r.err("aggregate_score: an incomplete result set did not score 0.0")
+        if agg([]) != 0.0:
+            r.err("aggregate_score: an empty result set did not score 0.0")
+        if harbor_check:
+            for p in _harbor_verifier_check(agg(full)):
+                (r.warn if p.startswith("(") else r.err)(p)
+
+
+def validate_bundle(bundle: Path, harbor_check: bool = False) -> tuple[str, Report]:
+    r = Report()
+    shape = _detect_shape(bundle)
+    if shape == "unknown":
+        r.warn("could not detect bundle shape (no docker-compose.yaml or enabled_tools.txt); "
+               "running shared checks only")
+    _check_files(bundle, shape, r)
+    _check_scripts(bundle, r)
+    _check_task_toml(bundle, shape, r)
+    _check_agent_judge(bundle, harbor_check, r)
+    return shape, r
 
 
 def _iter_bundles(root: Path):
-    """A bundle is a dir containing task.toml. Accept a single bundle or a parent."""
     if (root / "task.toml").is_file():
         yield root
         return
@@ -285,21 +303,23 @@ def main() -> int:
 
     failed = 0
     for bundle in bundles:
-        problems = validate_bundle(bundle, harbor_check=args.harbor_check)
-        hard = [p for p in problems if not p.startswith("(")]
-        notes = [p for p in problems if p.startswith("(")]
-        if hard:
+        shape, r = validate_bundle(bundle, harbor_check=args.harbor_check)
+        if r.errors:
             failed += 1
-            print(f"FAIL {bundle.name}")
-            for pr in hard:
-                print(f"      - {pr}")
+            print(f"FAIL [{shape}] {bundle.name}")
+            for m in r.errors:
+                print(f"      - {m}")
+            for m in r.warnings:
+                print(f"      ~ {m}")
         else:
-            suffix = f"  {notes[0]}" if notes else ""
-            print(f"ok   {bundle.name}{suffix}")
+            tail = f"  ({len(r.warnings)} warning(s))" if r.warnings else ""
+            print(f"ok   [{shape}] {bundle.name}{tail}")
+            for m in r.warnings:
+                print(f"      ~ {m}")
 
     print(f"\n{len(bundles) - failed}/{len(bundles)} bundles valid", file=sys.stderr)
     if failed:
-        print(f"RESULT: FAILED ({failed} bundle(s) with problems)", file=sys.stderr)
+        print(f"RESULT: FAILED ({failed} bundle(s) with errors)", file=sys.stderr)
         return 1
     print("RESULT: PASSED", file=sys.stderr)
     return 0


### PR DESCRIPTION
## What

A post-format validation harness for Harbor task bundles — both **MCP RL** (single-image) and **MCP Advanced** (multi-service docker-compose) — so format/schema regressions are caught **before delivery** instead of at run time. Two complementary tools in `services/mcp_eval/`:

### 1. `validate_harbor_bundles.py` — static gate (deterministic, no Docker, CI-able)
Runs over every bundle in seconds. **Shape-aware**: detects `rl` (Dockerfile + `enabled_tools.txt`) vs `advanced` (`docker-compose.yaml`) and applies the right structural checks; the **verifier checks are shared** (both embed the same LLM-as-judge):
- file set; `task.toml` parses + `[verifier]` + `[[environment.mcp_servers]]`; RL: `[metadata].task_id` + `enabled_tools.txt` ↔ `task.toml` consistency.
- `agent_judge.py`: compiles, **module body execs cleanly** (catches the JSON-literal `NameError` class), non-empty `CRITERIA` / dict `OUTPUT_SCHEMA` / callable `aggregate_score` (full→1.0, incomplete/empty→0.0), and a **flat scalar `reward.json`** (AST + light dataflow, so a list *variable* like `verified_results` is flagged, not just literals). `--harbor-check` cross-checks against Harbor's real `VerifierResult`.
- Errors fail (non-zero exit); warnings (exec bit Harbor re-applies, optional `solution/`) are reported but don't fail.

### 2. `harbor_smoke.py` — live sanity gate (Tier-2/3)
Runs a **sample** of bundles through **real Harbor** under one or more `(harbor-binary, agent)` conditions and asserts each trial produced a valid reward (non-null `verifier_result`, scalar `reward` in [0,1], `exception_info == null`) — i.e. env builds, healthcheck passes, verifier runs, and **Harbor ingests the reward without a schema error**. Run it at minimum under the **latest json-first Harbor** (the condition that surfaces the reward.json bug); add a pinned Harbor and a real agent for breadth.
```
python harbor_smoke.py OUT/ --sample 5 --harbor <latest>/bin/harbor --agent nop
python harbor_smoke.py OUT/ --sample 5 --harbor <latest>/bin/harbor --harbor <pinned>/bin/harbor --agent nop --agent claude-code -m claude-sonnet-4-6
```

## Verified (static, locally)
- Mixed **RL + Advanced** set → all pass.
- The delivered (buggy) Advanced bundle → fails on **only the real judge bugs** (reward.json non-scalar, missing aggregate guard) with **no structural false-positives**; a re-rendered (fixed) Advanced bundle passes.
- Six deliberately-broken classes each caught: missing file, non-scalar reward.json (`verified_results`), `NameError` judge, non-exec script, empty `CRITERIA`, `enabled_tools` drift.

## Pending
- Live `harbor_smoke.py` run on the devbox over a handful of RL + Advanced bundles under Harbor 0.13.0 (devbox currently stopped) — to attach as the e2e proof.
- Follow-ups: wire `--validate` into the converter; agent-env generator fix so freshly-generated Advanced bundles pass the judge checks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new pre-delivery gate scripts for Harbor task bundles: a deterministic static validator (`validate_harbor_bundles.py`) that catches schema/structural regressions without Docker or an LLM, and an end-to-end smoke runner (`harbor_smoke.py`) that exercises real Harbor runs over a sample of bundles.

- `validate_harbor_bundles.py` checks file presence, script shebangs, `task.toml` structure, and `agent_judge.py` correctness (via AST analysis and live `exec`), with a `--harbor-check` flag that validates against Harbor's own `VerifierResult` model.
- `harbor_smoke.py` samples bundles, runs each through one or more (Harbor binary, agent) conditions, and asserts the trial-level result contains a valid numeric reward; the `_find_trial_result` helper's traversal order is nondeterministic and may select the wrong `result.json` when multiple matching files are present.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the static validator; the smoke runner has a result-selection bug that can silently report a job-level verdict instead of the trial-level one, producing a misleading PASS or FAIL for a bundle.

The static validator in validate_harbor_bundles.py is self-contained and the logic is sound for its intended use. The smoke runner in harbor_smoke.py relies on unspecified rglob iteration order to choose between multiple result.json files; when Harbor writes both a job-level and a trial-level file containing the expected keys, the function may return the wrong dict and misreport the verdict.

services/mcp_eval/harbor_smoke.py — _find_trial_result needs depth-aware selection logic.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| services/mcp_eval/validate_harbor_bundles.py | New deterministic stdlib-only validator for Harbor task bundles; checks files, scripts, TOML structure, and agent_judge.py via AST + exec. Exec namespace missing __file__ can produce false NameError failures for judge files that reference their own path. |
| services/mcp_eval/harbor_smoke.py | New end-to-end smoke-test runner that samples bundles through real Harbor; _find_trial_result relies on undefined rglob iteration order to pick the trial-level result.json over a job-level one, which can silently return the wrong result. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validate_harbor_bundles.py main] --> B[_iter_bundles]
    B --> C[validate_bundle]
    C --> D[_detect_shape: rl / advanced / unknown]
    D --> E[_check_files: required file set + instruction.md]
    E --> F[_check_scripts: shebang + exec bit]
    F --> G[_check_task_toml: tomllib parse + metadata + servers + enabled_tools drift]
    G --> H[_check_agent_judge]
    H --> H1[_reward_json_violations: AST + dataflow scalar reward values]
    H --> H2[_exec_judge: exec module body, restore env]
    H2 --> H3[inspect CRITERIA, OUTPUT_SCHEMA, aggregate_score]
    H3 --> H4{--harbor-check?}
    H4 -- yes --> H5[_harbor_verifier_check: Harbor VerifierResult]
    H4 -- no --> I
    H5 --> I[Report: errors / warnings]
    I --> J{errors?}
    J -- yes --> K[FAIL: non-zero exit]
    J -- no --> L[ok: zero exit]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aservices%2Fmcp_eval%2Fharbor_smoke.py%3A57-67%0A**Non-deterministic%20traversal%20returns%20the%20wrong%20result.json**%0A%0A%60rglob%28%22result.json%22%29%60%20yields%20files%20in%20an%20unspecified%2C%20filesystem-dependent%20order.%20The%20loop%20assigns%20%60best%20%3D%20data%60%20on%20every%20matching%20file%20and%20returns%20whichever%20was%20visited%20last%20%E2%80%94%20which%20is%20not%20necessarily%20the%20deepest%20%28trial-level%29%20file.%20If%20Harbor%20writes%20both%20a%20job-level%20and%20a%20trial-level%20%60result.json%60%20that%20both%20contain%20%60%22verifier_result%22%60%20or%20%60%22exception_info%22%60%20keys%2C%20the%20function%20may%20return%20the%20job-level%20dict%2C%20causing%20%60_verdict%60%20to%20misreport%20the%20trial%20outcome.%20The%20comment%20%22prefer%20the%20deepest%2Flast%20%28trial-level%29%22%20describes%20the%20intended%20semantics%20but%20the%20current%20code%20does%20not%20implement%20them.%0A%0ATo%20select%20the%20deepest%20match%2C%20track%20the%20winning%20path%20alongside%20the%20data%20and%20replace%20%60best%60%20only%20when%20the%20candidate%20is%20deeper%3A%0A%60%60%60%0Abest%2C%20best_rj%20%3D%20None%2C%20None%0Afor%20rj%20in%20out_dir.rglob%28%22result.json%22%29%3A%0A%20%20%20%20...%0A%20%20%20%20if%20isinstance%28data%2C%20dict%29%20and%20%28...%29%3A%0A%20%20%20%20%20%20%20%20if%20best_rj%20is%20None%20or%20len%28rj.parts%29%20%3E%20len%28best_rj.parts%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20best%2C%20best_rj%20%3D%20data%2C%20rj%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aservices%2Fmcp_eval%2Fvalidate_harbor_bundles.py%3A209%0A%60_exec_judge%60%20builds%20its%20namespace%20with%20only%20%60__name__%60%20set%2C%20so%20%60__file__%60%20is%20absent.%20Any%20judge%20file%20that%20references%20its%20own%20path%20%28e.g.%2C%20%60Path%28__file__%29.parent%20%2F%20%22template.json%22%60%29%20will%20raise%20%60NameError%3A%20name%20'__file__'%20is%20not%20defined%60%20during%20exec%2C%20which%20the%20caller%20catches%20and%20reports%20as%20%22agent_judge.py%20module%20body%20fails%20to%20exec%22%20%E2%80%94%20a%20false%20failure%20that%20blocks%20valid%20bundles.%20Adding%20%60__file__%60%20to%20the%20initial%20namespace%20%28by%20threading%20the%20file%20path%20through%20from%20%60_check_agent_judge%60%29%20prevents%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20ns%3A%20dict%20%3D%20%7B%22__name__%22%3A%20%22_harbor_bundle_validate%22%2C%20%22__file__%22%3A%20str%28bundle%29%7D%0A%60%60%60%0A%0A&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aservices%2Fmcp_eval%2Fharbor_smoke.py%3A57-67%0A**Non-deterministic%20traversal%20returns%20the%20wrong%20result.json**%0A%0A%60rglob%28%22result.json%22%29%60%20yields%20files%20in%20an%20unspecified%2C%20filesystem-dependent%20order.%20The%20loop%20assigns%20%60best%20%3D%20data%60%20on%20every%20matching%20file%20and%20returns%20whichever%20was%20visited%20last%20%E2%80%94%20which%20is%20not%20necessarily%20the%20deepest%20%28trial-level%29%20file.%20If%20Harbor%20writes%20both%20a%20job-level%20and%20a%20trial-level%20%60result.json%60%20that%20both%20contain%20%60%22verifier_result%22%60%20or%20%60%22exception_info%22%60%20keys%2C%20the%20function%20may%20return%20the%20job-level%20dict%2C%20causing%20%60_verdict%60%20to%20misreport%20the%20trial%20outcome.%20The%20comment%20%22prefer%20the%20deepest%2Flast%20%28trial-level%29%22%20describes%20the%20intended%20semantics%20but%20the%20current%20code%20does%20not%20implement%20them.%0A%0ATo%20select%20the%20deepest%20match%2C%20track%20the%20winning%20path%20alongside%20the%20data%20and%20replace%20%60best%60%20only%20when%20the%20candidate%20is%20deeper%3A%0A%60%60%60%0Abest%2C%20best_rj%20%3D%20None%2C%20None%0Afor%20rj%20in%20out_dir.rglob%28%22result.json%22%29%3A%0A%20%20%20%20...%0A%20%20%20%20if%20isinstance%28data%2C%20dict%29%20and%20%28...%29%3A%0A%20%20%20%20%20%20%20%20if%20best_rj%20is%20None%20or%20len%28rj.parts%29%20%3E%20len%28best_rj.parts%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20best%2C%20best_rj%20%3D%20data%2C%20rj%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aservices%2Fmcp_eval%2Fvalidate_harbor_bundles.py%3A209%0A%60_exec_judge%60%20builds%20its%20namespace%20with%20only%20%60__name__%60%20set%2C%20so%20%60__file__%60%20is%20absent.%20Any%20judge%20file%20that%20references%20its%20own%20path%20%28e.g.%2C%20%60Path%28__file__%29.parent%20%2F%20%22template.json%22%60%29%20will%20raise%20%60NameError%3A%20name%20'__file__'%20is%20not%20defined%60%20during%20exec%2C%20which%20the%20caller%20catches%20and%20reports%20as%20%22agent_judge.py%20module%20body%20fails%20to%20exec%22%20%E2%80%94%20a%20false%20failure%20that%20blocks%20valid%20bundles.%20Adding%20%60__file__%60%20to%20the%20initial%20namespace%20%28by%20threading%20the%20file%20path%20through%20from%20%60_check_agent_judge%60%29%20prevents%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20ns%3A%20dict%20%3D%20%7B%22__name__%22%3A%20%22_harbor_bundle_validate%22%2C%20%22__file__%22%3A%20str%28bundle%29%7D%0A%60%60%60%0A%0A&repo=scaleapi%2Fmcp-atlas&pr=36&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fmcp-atlas%22%20on%20the%20existing%20branch%20%22cikowski%2Fharbor-bundle-validator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cikowski%2Fharbor-bundle-validator%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aservices%2Fmcp_eval%2Fharbor_smoke.py%3A57-67%0A**Non-deterministic%20traversal%20returns%20the%20wrong%20result.json**%0A%0A%60rglob%28%22result.json%22%29%60%20yields%20files%20in%20an%20unspecified%2C%20filesystem-dependent%20order.%20The%20loop%20assigns%20%60best%20%3D%20data%60%20on%20every%20matching%20file%20and%20returns%20whichever%20was%20visited%20last%20%E2%80%94%20which%20is%20not%20necessarily%20the%20deepest%20%28trial-level%29%20file.%20If%20Harbor%20writes%20both%20a%20job-level%20and%20a%20trial-level%20%60result.json%60%20that%20both%20contain%20%60%22verifier_result%22%60%20or%20%60%22exception_info%22%60%20keys%2C%20the%20function%20may%20return%20the%20job-level%20dict%2C%20causing%20%60_verdict%60%20to%20misreport%20the%20trial%20outcome.%20The%20comment%20%22prefer%20the%20deepest%2Flast%20%28trial-level%29%22%20describes%20the%20intended%20semantics%20but%20the%20current%20code%20does%20not%20implement%20them.%0A%0ATo%20select%20the%20deepest%20match%2C%20track%20the%20winning%20path%20alongside%20the%20data%20and%20replace%20%60best%60%20only%20when%20the%20candidate%20is%20deeper%3A%0A%60%60%60%0Abest%2C%20best_rj%20%3D%20None%2C%20None%0Afor%20rj%20in%20out_dir.rglob%28%22result.json%22%29%3A%0A%20%20%20%20...%0A%20%20%20%20if%20isinstance%28data%2C%20dict%29%20and%20%28...%29%3A%0A%20%20%20%20%20%20%20%20if%20best_rj%20is%20None%20or%20len%28rj.parts%29%20%3E%20len%28best_rj.parts%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20best%2C%20best_rj%20%3D%20data%2C%20rj%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aservices%2Fmcp_eval%2Fvalidate_harbor_bundles.py%3A209%0A%60_exec_judge%60%20builds%20its%20namespace%20with%20only%20%60__name__%60%20set%2C%20so%20%60__file__%60%20is%20absent.%20Any%20judge%20file%20that%20references%20its%20own%20path%20%28e.g.%2C%20%60Path%28__file__%29.parent%20%2F%20%22template.json%22%60%29%20will%20raise%20%60NameError%3A%20name%20'__file__'%20is%20not%20defined%60%20during%20exec%2C%20which%20the%20caller%20catches%20and%20reports%20as%20%22agent_judge.py%20module%20body%20fails%20to%20exec%22%20%E2%80%94%20a%20false%20failure%20that%20blocks%20valid%20bundles.%20Adding%20%60__file__%60%20to%20the%20initial%20namespace%20%28by%20threading%20the%20file%20path%20through%20from%20%60_check_agent_judge%60%29%20prevents%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20ns%3A%20dict%20%3D%20%7B%22__name__%22%3A%20%22_harbor_bundle_validate%22%2C%20%22__file__%22%3A%20str%28bundle%29%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
services/mcp_eval/harbor_smoke.py:57-67
**Non-deterministic traversal returns the wrong result.json**

`rglob("result.json")` yields files in an unspecified, filesystem-dependent order. The loop assigns `best = data` on every matching file and returns whichever was visited last — which is not necessarily the deepest (trial-level) file. If Harbor writes both a job-level and a trial-level `result.json` that both contain `"verifier_result"` or `"exception_info"` keys, the function may return the job-level dict, causing `_verdict` to misreport the trial outcome. The comment "prefer the deepest/last (trial-level)" describes the intended semantics but the current code does not implement them.

To select the deepest match, track the winning path alongside the data and replace `best` only when the candidate is deeper:
```
best, best_rj = None, None
for rj in out_dir.rglob("result.json"):
    ...
    if isinstance(data, dict) and (...):
        if best_rj is None or len(rj.parts) > len(best_rj.parts):
            best, best_rj = data, rj
```

### Issue 2 of 2
services/mcp_eval/validate_harbor_bundles.py:209
`_exec_judge` builds its namespace with only `__name__` set, so `__file__` is absent. Any judge file that references its own path (e.g., `Path(__file__).parent / "template.json"`) will raise `NameError: name '__file__' is not defined` during exec, which the caller catches and reports as "agent_judge.py module body fails to exec" — a false failure that blocks valid bundles. Adding `__file__` to the initial namespace (by threading the file path through from `_check_agent_judge`) prevents this.

```suggestion
    ns: dict = {"__name__": "_harbor_bundle_validate", "__file__": str(bundle)}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(mcp\_eval): shape-aware validator (R..."](https://github.com/scaleapi/mcp-atlas/commit/5402213185eafe78e3250c7d85b04a10018e736c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35667383)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->