### PR TITLE
fix(agent-environment): sync MCP install script with template pins (#34)

### DIFF
--- a/services/agent-environment/README.md
+++ b/services/agent-environment/README.md
@@ -56,3 +56,10 @@ This depends on https://github.com/jlowin/fastmcp
 By default, caching is enabled. If a request is successful, it will be cached, and subsequent identical requests will return the cached value.
 
 At high throughputs, some of the MCP servers may not perform as well or may freeze up. Replicas are recommended for high throughput.
+
+## Pinned MCP server versions
+
+`mcp_server_template.json` is the source of truth for MCP package pins. `dev_scripts/install_mcp_packages.sh` must stay in sync (`pytest tests/test_mcp_config_sync.py`).
+
+The filesystem server must be `@modelcontextprotocol/server-filesystem@2025.12.18` or newer. `@2025.11.25` fails MCP output validation on `directory_tree` (see [issue #34](https://github.com/scaleapi/mcp-atlas/issues/34) and [modelcontextprotocol/servers#3110](https://github.com/modelcontextprotocol/servers/issues/3110)). `tests/test_filesystem_pin.py` enforces the minimum pin.
+

--- a/services/agent-environment/dev_scripts/install_mcp_packages.sh
+++ b/services/agent-environment/dev_scripts/install_mcp_packages.sh
@@ -13,7 +13,7 @@ npm install -g \
     @wonderwhy-er/desktop-commander@0.2.7 \
     @e2b/mcp-server@0.2.0 \
     exa-mcp-server@0.3.10 \
-    @modelcontextprotocol/server-filesystem@2025.11.25 \
+    @modelcontextprotocol/server-filesystem@2026.7.10 \
     @modelcontextprotocol/server-google-maps@0.6.2 \
     @geobio/google-workspace-server@0.1.0 \
     @translated/lara-mcp@0.0.11 \
@@ -33,11 +33,12 @@ echo "Installing UVX MCP server packages..."
 uv tool install arxiv-mcp-server==0.2.11
 uv tool install mcp-server-calculator==0.2.0
 uv tool install cli-mcp-server==0.2.5
-uv tool install duckduckgo-mcp-server==0.1.1
+uv tool install duckduckgo-mcp-server==0.5.0
 uv tool install mcp-server-fetch==2025.4.7
 uv tool install mcp-server-git==2025.7.1
 uv tool install osm-mcp-server==0.1.1
 uv tool install oxylabs-mcp==0.4.1
 uv tool install mcp-server-twelve-data==0.2.5
+uv tool install wikipedia-mcp==2.0.1
 
 echo "All UVX/NPX MCP packages installation complete. Ignored any that install from github!" 

--- a/services/agent-environment/tests/test_filesystem_pin.py
+++ b/services/agent-environment/tests/test_filesystem_pin.py
@@ -1,0 +1,56 @@
+"""
+Regression guard for scaleapi/mcp-atlas#34.
+
+The filesystem MCP server @2025.11.25 returns structured content for
+directory_tree that fails MCP output validation (-32602). Fixed upstream in
+modelcontextprotocol/servers#3113 (2025.12.18+).
+
+Template is source of truth; install_mcp_packages.sh must stay in sync
+(test_mcp_config_sync.py). This test additionally enforces a minimum pin.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+TEMPLATE = (
+    Path(__file__).parent.parent
+    / "src"
+    / "agent_environment"
+    / "mcp_server_template.json"
+)
+
+# CalVer components — reject pins before the upstream fix shipped.
+MIN_FILESYSTEM_CALVER = (2025, 12, 18)
+KNOWN_BAD_FILESYSTEM_CALVER = (2025, 11, 25)
+
+
+def _parse_calver(version: str) -> tuple[int, ...]:
+    parts = version.split(".")
+    return tuple(int(p) for p in parts)
+
+
+def _filesystem_pin_from_template() -> str:
+    with open(TEMPLATE) as f:
+        data = json.load(f)
+    args = data["mcpServers"]["filesystem"]["args"]
+    for arg in args:
+        if arg.startswith("@modelcontextprotocol/server-filesystem@"):
+            return arg
+    raise AssertionError("filesystem server pin not found in mcp_server_template.json")
+
+
+def test_filesystem_pin_meets_minimum_for_directory_tree():
+    pin = _filesystem_pin_from_template()
+    match = re.search(r"@([\d.]+)$", pin)
+    assert match, f"unexpected filesystem pin format: {pin}"
+    calver = _parse_calver(match.group(1))
+    assert calver >= MIN_FILESYSTEM_CALVER, (
+        f"filesystem pin {pin} is below minimum {MIN_FILESYSTEM_CALVER} "
+        "(directory_tree MCP validation — see #34)"
+    )
+    assert calver != KNOWN_BAD_FILESYSTEM_CALVER, (
+        "pin must not be 2025.11.25 — known broken for directory_tree (#34)"
+    )


### PR DESCRIPTION
## Problem

`mcp_server_template.json` bumped `@modelcontextprotocol/server-filesystem` to `2026.7.10` but `dev_scripts/install_mcp_packages.sh` still installed `@2025.11.25`. Docker builds use the install script, so images could ship the broken pin — every `directory_tree` call fails MCP output validation (-32602) regardless of model (see #34, modelcontextprotocol/servers#3110).

Also drifted: `duckduckgo-mcp-server` (0.1.1 vs 0.5.0) and `wikipedia-mcp` (missing from install script).

## Repro

```bash
cd services/agent-environment
python3 -m pytest tests/test_mcp_config_sync.py -v
```

Fails on main before this fix (NPX version mismatch on filesystem pin).

## Fix

- Sync `install_mcp_packages.sh` to match template pins
- Add `tests/test_filesystem_pin.py` — minimum calver guard for #34
- Document pin policy in `services/agent-environment/README.md`

## Verification

```bash
cd services/agent-environment
python3 -m pytest tests/ -v
```

Both `test_package_sync` and `test_filesystem_pin_meets_minimum_for_directory_tree` pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs `dev_scripts/install_mcp_packages.sh` with `mcp_server_template.json` to fix a version drift that caused every `directory_tree` call to fail with MCP output validation error -32602 when using the `@2025.11.25` filesystem server pin.

- Bumps `@modelcontextprotocol/server-filesystem` from `2025.11.25` to `2026.7.10`, `duckduckgo-mcp-server` from `0.1.1` to `0.5.0`, and adds `wikipedia-mcp==2.0.1` to the install script.
- Adds `tests/test_filesystem_pin.py` as a regression guard enforcing the minimum CalVer pin, and documents the pin policy in `README.md`.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The version bump and sync are correct and well-guarded by two new tests; only minor polish issues remain.

The core changes — version pin updates and the new CalVer regression guard — address a real runtime breakage. The only findings are a redundant assertion, an upstream issue-number discrepancy in a docstring, and a missing trailing newline in the shell script, none of which affect runtime behavior.

The docstring in `tests/test_filesystem_pin.py` references a different upstream issue number than the PR description; worth a quick double-check before merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| services/agent-environment/dev_scripts/install_mcp_packages.sh | Bumps filesystem server from 2025.11.25 to 2026.7.10, duckduckgo from 0.1.1 to 0.5.0, and adds wikipedia-mcp==2.0.1 to align with template pins; still missing trailing newline. |
| services/agent-environment/tests/test_filesystem_pin.py | New regression guard that reads the template JSON and verifies the filesystem CalVer pin meets the minimum; contains a logically redundant second assertion and an upstream issue-number discrepancy in its docstring. |
| services/agent-environment/README.md | Adds pin-policy documentation explaining the template-as-source-of-truth contract and the minimum filesystem version required to avoid -32602 errors. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aservices%2Fagent-environment%2Ftests%2Ftest_filesystem_pin.py%3A50-56%0AThe%20second%20assertion%20is%20logically%20redundant%3A%20if%20%60calver%20%3E%3D%20MIN_FILESYSTEM_CALVER%60%20%282025%2C%2012%2C%2018%29%20passes%2C%20the%20result%20can%20never%20equal%20%60KNOWN_BAD_FILESYSTEM_CALVER%60%20%282025%2C%2011%2C%2025%29%20since%20that%20value%20is%20strictly%20less%20than%20the%20minimum.%20The%20extra%20check%20adds%20noise%20without%20catching%20any%20additional%20cases.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert%20calver%20%3E%3D%20MIN_FILESYSTEM_CALVER%2C%20%28%0A%20%20%20%20%20%20%20%20f%22filesystem%20pin%20%7Bpin%7D%20is%20below%20minimum%20%7BMIN_FILESYSTEM_CALVER%7D%20%22%0A%20%20%20%20%20%20%20%20%22%28directory_tree%20MCP%20validation%20%E2%80%94%20see%20%2334%29%22%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aservices%2Fagent-environment%2Ftests%2Ftest_filesystem_pin.py%3A4-6%0AThe%20PR%20description%20cites%20%60modelcontextprotocol%2Fservers%233110%60%20as%20the%20upstream%20bug%20report%2C%20but%20the%20module%20docstring%20references%20%60%233113%60.%20These%20point%20to%20different%20issues%20%E2%80%94%20one%20of%20the%20two%20is%20wrong%20and%20will%20mislead%20anyone%20tracing%20the%20fix.%0A%0A%60%60%60suggestion%0AThe%20filesystem%20MCP%20server%20%402025.11.25%20returns%20structured%20content%20for%0Adirectory_tree%20that%20fails%20MCP%20output%20validation%20%28-32602%29.%20Fixed%20upstream%20in%0Amodelcontextprotocol%2Fservers%233110%20%282025.12.18%2B%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aservices%2Fagent-environment%2Fdev_scripts%2Finstall_mcp_packages.sh%3A44%0AThe%20file%20is%20still%20missing%20a%20trailing%20newline%20%28the%20diff%20shows%20%60%5C%20No%20newline%20at%20end%20of%20file%60%29.%20POSIX%20requires%20text%20files%20to%20end%20with%20a%20newline%2C%20and%20some%20tools%20%28e.g.%20%60cat%60%2C%20%60wc%20-l%60%29%20behave%20unexpectedly%20without%20one.%0A%0A%60%60%60suggestion%0Aecho%20%22All%20UVX%2FNPX%20MCP%20packages%20installation%20complete.%20Ignored%20any%20that%20install%20from%20github!%22%0A%60%60%60%0A%0A&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aservices%2Fagent-environment%2Ftests%2Ftest_filesystem_pin.py%3A50-56%0AThe%20second%20assertion%20is%20logically%20redundant%3A%20if%20%60calver%20%3E%3D%20MIN_FILESYSTEM_CALVER%60%20%282025%2C%2012%2C%2018%29%20passes%2C%20the%20result%20can%20never%20equal%20%60KNOWN_BAD_FILESYSTEM_CALVER%60%20%282025%2C%2011%2C%2025%29%20since%20that%20value%20is%20strictly%20less%20than%20the%20minimum.%20The%20extra%20check%20adds%20noise%20without%20catching%20any%20additional%20cases.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert%20calver%20%3E%3D%20MIN_FILESYSTEM_CALVER%2C%20%28%0A%20%20%20%20%20%20%20%20f%22filesystem%20pin%20%7Bpin%7D%20is%20below%20minimum%20%7BMIN_FILESYSTEM_CALVER%7D%20%22%0A%20%20%20%20%20%20%20%20%22%28directory_tree%20MCP%20validation%20%E2%80%94%20see%20%2334%29%22%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aservices%2Fagent-environment%2Ftests%2Ftest_filesystem_pin.py%3A4-6%0AThe%20PR%20description%20cites%20%60modelcontextprotocol%2Fservers%233110%60%20as%20the%20upstream%20bug%20report%2C%20but%20the%20module%20docstring%20references%20%60%233113%60.%20These%20point%20to%20different%20issues%20%E2%80%94%20one%20of%20the%20two%20is%20wrong%20and%20will%20mislead%20anyone%20tracing%20the%20fix.%0A%0A%60%60%60suggestion%0AThe%20filesystem%20MCP%20server%20%402025.11.25%20returns%20structured%20content%20for%0Adirectory_tree%20that%20fails%20MCP%20output%20validation%20%28-32602%29.%20Fixed%20upstream%20in%0Amodelcontextprotocol%2Fservers%233110%20%282025.12.18%2B%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aservices%2Fagent-environment%2Fdev_scripts%2Finstall_mcp_packages.sh%3A44%0AThe%20file%20is%20still%20missing%20a%20trailing%20newline%20%28the%20diff%20shows%20%60%5C%20No%20newline%20at%20end%20of%20file%60%29.%20POSIX%20requires%20text%20files%20to%20end%20with%20a%20newline%2C%20and%20some%20tools%20%28e.g.%20%60cat%60%2C%20%60wc%20-l%60%29%20behave%20unexpectedly%20without%20one.%0A%0A%60%60%60suggestion%0Aecho%20%22All%20UVX%2FNPX%20MCP%20packages%20installation%20complete.%20Ignored%20any%20that%20install%20from%20github!%22%0A%60%60%60%0A%0A&repo=scaleapi%2Fmcp-atlas&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fmcp-atlas%22%20on%20the%20existing%20branch%20%22fix%2Fmcp-atlas-fs-pin-sync%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmcp-atlas-fs-pin-sync%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aservices%2Fagent-environment%2Ftests%2Ftest_filesystem_pin.py%3A50-56%0AThe%20second%20assertion%20is%20logically%20redundant%3A%20if%20%60calver%20%3E%3D%20MIN_FILESYSTEM_CALVER%60%20%282025%2C%2012%2C%2018%29%20passes%2C%20the%20result%20can%20never%20equal%20%60KNOWN_BAD_FILESYSTEM_CALVER%60%20%282025%2C%2011%2C%2025%29%20since%20that%20value%20is%20strictly%20less%20than%20the%20minimum.%20The%20extra%20check%20adds%20noise%20without%20catching%20any%20additional%20cases.%0A%0A%60%60%60suggestion%0A%20%20%20%20assert%20calver%20%3E%3D%20MIN_FILESYSTEM_CALVER%2C%20%28%0A%20%20%20%20%20%20%20%20f%22filesystem%20pin%20%7Bpin%7D%20is%20below%20minimum%20%7BMIN_FILESYSTEM_CALVER%7D%20%22%0A%20%20%20%20%20%20%20%20%22%28directory_tree%20MCP%20validation%20%E2%80%94%20see%20%2334%29%22%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aservices%2Fagent-environment%2Ftests%2Ftest_filesystem_pin.py%3A4-6%0AThe%20PR%20description%20cites%20%60modelcontextprotocol%2Fservers%233110%60%20as%20the%20upstream%20bug%20report%2C%20but%20the%20module%20docstring%20references%20%60%233113%60.%20These%20point%20to%20different%20issues%20%E2%80%94%20one%20of%20the%20two%20is%20wrong%20and%20will%20mislead%20anyone%20tracing%20the%20fix.%0A%0A%60%60%60suggestion%0AThe%20filesystem%20MCP%20server%20%402025.11.25%20returns%20structured%20content%20for%0Adirectory_tree%20that%20fails%20MCP%20output%20validation%20%28-32602%29.%20Fixed%20upstream%20in%0Amodelcontextprotocol%2Fservers%233110%20%282025.12.18%2B%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aservices%2Fagent-environment%2Fdev_scripts%2Finstall_mcp_packages.sh%3A44%0AThe%20file%20is%20still%20missing%20a%20trailing%20newline%20%28the%20diff%20shows%20%60%5C%20No%20newline%20at%20end%20of%20file%60%29.%20POSIX%20requires%20text%20files%20to%20end%20with%20a%20newline%2C%20and%20some%20tools%20%28e.g.%20%60cat%60%2C%20%60wc%20-l%60%29%20behave%20unexpectedly%20without%20one.%0A%0A%60%60%60suggestion%0Aecho%20%22All%20UVX%2FNPX%20MCP%20packages%20installation%20complete.%20Ignored%20any%20that%20install%20from%20github!%22%0A%60%60%60%0A%0A&repo=scaleapi%2Fmcp-atlas&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
services/agent-environment/tests/test_filesystem_pin.py:50-56
The second assertion is logically redundant: if `calver >= MIN_FILESYSTEM_CALVER` (2025, 12, 18) passes, the result can never equal `KNOWN_BAD_FILESYSTEM_CALVER` (2025, 11, 25) since that value is strictly less than the minimum. The extra check adds noise without catching any additional cases.

```suggestion
    assert calver >= MIN_FILESYSTEM_CALVER, (
        f"filesystem pin {pin} is below minimum {MIN_FILESYSTEM_CALVER} "
        "(directory_tree MCP validation — see #34)"
    )
```

### Issue 2 of 3
services/agent-environment/tests/test_filesystem_pin.py:4-6
The PR description cites `modelcontextprotocol/servers#3110` as the upstream bug report, but the module docstring references `#3113`. These point to different issues — one of the two is wrong and will mislead anyone tracing the fix.

```suggestion
The filesystem MCP server @2025.11.25 returns structured content for
directory_tree that fails MCP output validation (-32602). Fixed upstream in
modelcontextprotocol/servers#3110 (2025.12.18+).
```

### Issue 3 of 3
services/agent-environment/dev_scripts/install_mcp_packages.sh:44
The file is still missing a trailing newline (the diff shows `\ No newline at end of file`). POSIX requires text files to end with a newline, and some tools (e.g. `cat`, `wc -l`) behave unexpectedly without one.

```suggestion
echo "All UVX/NPX MCP packages installation complete. Ignored any that install from github!"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent-environment): sync MCP install..."](https://github.com/scaleapi/mcp-atlas/commit/9c0bc6098784093daf5c547fe9712ed99d31476e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43480904)</sub>

<!-- /greptile_comment -->