### PR TITLE
fix(agent-environment): advertise MCP client roots during list_tools

### DIFF
--- a/env.template
+++ b/env.template
@@ -103,6 +103,10 @@ MCP_SANDBOX_URL=http://localhost:1984
 # LIST_TOOLS_TIMEOUT_MS=180000
 # LLM_TIMEOUT_MS=600000
 
+# Filesystem roots advertised to MCP servers by agent-environment (comma-separated).
+# Default /data matches desktop-commander and filesystem server paths in the container.
+# MCP_CLIENT_ROOTS=/data
+
 # ---------------------------------------------------------------------------
 # Evaluation / Diagnostic scripts (services/scoring, services/diagnostics)
 # ---------------------------------------------------------------------------

--- a/services/agent-environment/README.md
+++ b/services/agent-environment/README.md
@@ -53,6 +53,8 @@ Check `env.template` for all available API key configurations.
 ## Implementation details
 This depends on https://github.com/jlowin/fastmcp
 
+The FastMCP client advertises filesystem roots to MCP servers (default: `/data`). Without roots, filesystem-related servers can log `Failed to request initial roots from client` during `list_tools` ([issue #17](https://github.com/scaleapi/mcp-atlas/issues/17), [#18](https://github.com/scaleapi/mcp-atlas/issues/18)). Override with comma-separated `MCP_CLIENT_ROOTS` in `.env`.
+
 By default, caching is enabled. If a request is successful, it will be cached, and subsequent identical requests will return the cached value.
 
 At high throughputs, some of the MCP servers may not perform as well or may freeze up. Replicas are recommended for high throughput.

--- a/services/agent-environment/src/agent_environment/client_roots.py
+++ b/services/agent-environment/src/agent_environment/client_roots.py
@@ -11,6 +11,8 @@ DEFAULT_CLIENT_ROOTS = ["/data"]
 
 def parse_client_roots(raw: str | None = None) -> list[str]:
     """Parse MCP_CLIENT_ROOTS (comma-separated paths) for the FastMCP client."""
-    value = raw if raw is not None else os.getenv("MCP_CLIENT_ROOTS", "/data")
+    value = raw if raw is not None else os.getenv(
+        "MCP_CLIENT_ROOTS", ",".join(DEFAULT_CLIENT_ROOTS)
+    )
     roots = [path.strip() for path in value.split(",") if path.strip()]
     return roots if roots else list(DEFAULT_CLIENT_ROOTS)

--- a/services/agent-environment/src/agent_environment/client_roots.py
+++ b/services/agent-environment/src/agent_environment/client_roots.py
@@ -1,0 +1,16 @@
+"""MCP client roots exposed to filesystem-related MCP servers."""
+
+from __future__ import annotations
+
+import os
+
+# Matches desktop-commander allowedDirectories and filesystem server paths in
+# mcp_server_template.json.
+DEFAULT_CLIENT_ROOTS = ["/data"]
+
+
+def parse_client_roots(raw: str | None = None) -> list[str]:
+    """Parse MCP_CLIENT_ROOTS (comma-separated paths) for the FastMCP client."""
+    value = raw if raw is not None else os.getenv("MCP_CLIENT_ROOTS", "/data")
+    roots = [path.strip() for path in value.split(",") if path.strip()]
+    return roots if roots else list(DEFAULT_CLIENT_ROOTS)

--- a/services/agent-environment/src/agent_environment/mcp_client.py
+++ b/services/agent-environment/src/agent_environment/mcp_client.py
@@ -1,5 +1,6 @@
 from fastmcp import Client
 from fastmcp.client.logging import LogMessage
+from .client_roots import parse_client_roots
 from .logger import create_logger
 import json
 import random
@@ -147,7 +148,11 @@ async def log_handler(message: LogMessage) -> None:
             logger.info(data)
 
 
+client_roots = parse_client_roots()
+logger.info(f"MCP client roots: {client_roots}")
+
 client: Client = Client(
     config,
     log_handler=log_handler,
+    roots=client_roots,
 )

--- a/services/agent-environment/tests/test_client_roots.py
+++ b/services/agent-environment/tests/test_client_roots.py
@@ -1,0 +1,21 @@
+"""Tests for MCP client roots configuration."""
+
+from agent_environment.client_roots import DEFAULT_CLIENT_ROOTS, parse_client_roots
+
+
+def test_default_roots():
+    assert parse_client_roots(None) == DEFAULT_CLIENT_ROOTS
+    assert parse_client_roots("") == DEFAULT_CLIENT_ROOTS
+    assert parse_client_roots("   ") == DEFAULT_CLIENT_ROOTS
+
+
+def test_single_root():
+    assert parse_client_roots("/data") == ["/data"]
+
+
+def test_multiple_roots():
+    assert parse_client_roots("/data,/tmp/workspace") == ["/data", "/tmp/workspace"]
+
+
+def test_strips_whitespace():
+    assert parse_client_roots(" /data , /tmp ") == ["/data", "/tmp"]

--- a/services/agent-environment/tests/test_client_roots.py
+++ b/services/agent-environment/tests/test_client_roots.py
@@ -3,7 +3,8 @@
 from agent_environment.client_roots import DEFAULT_CLIENT_ROOTS, parse_client_roots
 
 
-def test_default_roots():
+def test_default_roots(monkeypatch):
+    monkeypatch.delenv("MCP_CLIENT_ROOTS", raising=False)
     assert parse_client_roots(None) == DEFAULT_CLIENT_ROOTS
     assert parse_client_roots("") == DEFAULT_CLIENT_ROOTS
     assert parse_client_roots("   ") == DEFAULT_CLIENT_ROOTS


### PR DESCRIPTION
## Summary

- Register FastMCP client roots (default `/data`) so filesystem-related MCP servers get a timely `roots/list` response instead of timing out or logging `List roots not supported`.
- Add `parse_client_roots()` with unit tests and document `MCP_CLIENT_ROOTS` in `env.template`.

Fixes #17, #18

## Problem

During eval startup, MCP servers (notably filesystem) request initial roots from the client. The agent-environment `Client` was created without a `roots` handler, which produces intermittent:

```
Failed to request initial roots from client: MCP error -32001: Request timed out
Failed to request initial roots from client: MCP error -32603: List roots not supported
```

This can slow or destabilize `list_tools` when many servers start concurrently.

## Solution

Pass `roots=parse_client_roots()` to `fastmcp.Client`. Default is `/data`, matching `desktop-commander` `allowedDirectories` and filesystem paths in `mcp_server_template.json`. Override via comma-separated `MCP_CLIENT_ROOTS`.

## Test plan

- [x] `cd services/agent-environment && PYTHONPATH=src python3 -m pytest tests/test_client_roots.py tests/test_mcp_config_sync.py -v`
- [ ] `make build && make run-docker` with `ENABLED_SERVERS=filesystem,git` — confirm no roots timeout spam in logs during startup
- [ ] `curl -X POST http://localhost:1984/list-tools` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes intermittent `roots/list` timeout errors during `list_tools` startup by registering filesystem roots with the `fastmcp.Client`. It adds a small, focused `parse_client_roots()` helper, wires it into `mcp_client.py`, and documents the `MCP_CLIENT_ROOTS` env var. Previously flagged issues (hardcoded default in `os.getenv`, env isolation in tests) have both been resolved.

- **`client_roots.py`**: New module with `DEFAULT_CLIENT_ROOTS = ["/data"]` and `parse_client_roots()` that correctly references the constant as the `os.getenv` fallback, with a safe empty-list guard.
- **`mcp_client.py`**: Calls `parse_client_roots()` at module level and passes the result to `Client(roots=...)`, which FastMCP accepts as a `list[str]` and converts to `mcp.types.Root` objects internally.
- **`test_client_roots.py`**: Covers default, single, multi-root, and whitespace-stripping cases; a test for the env-var-is-set code path is missing but the rest of the logic is well validated.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, touches only startup initialization, and both previously reported issues have been corrected.

The new code is small and isolated: a pure-function parser, a module-level call that reads an env var at startup, and a single extra kwarg on the existing Client constructor. FastMCP documents list[str] as a valid roots input and handles the conversion to mcp.types.Root internally. There are no data-path or auth changes, and the fix directly addresses a known startup race condition.

No files require special attention. The only gap is a missing test for the env-var-is-set code path in test_client_roots.py, but the runtime behavior is straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| services/agent-environment/src/agent_environment/client_roots.py | New module exposing `parse_client_roots()` with correct DEFAULT_CLIENT_ROOTS reference in the `os.getenv` fallback and a safe fallback when the parsed list is empty. |
| services/agent-environment/src/agent_environment/mcp_client.py | Adds module-level `parse_client_roots()` call and passes the result as `roots=` to `fastmcp.Client`; `logger` is already initialised at line 11, so the new `logger.info` call is safe. |
| services/agent-environment/tests/test_client_roots.py | Unit tests cover default fallback (with env deletion via `monkeypatch`), single root, multiple roots, and whitespace stripping; the env-var-is-set path for `parse_client_roots(None)` is not tested but the core logic is validated. |
| env.template | Documents `MCP_CLIENT_ROOTS` in the correct section with a commented-out example and a clear description of the default. |
| services/agent-environment/README.md | Adds one sentence explaining the roots advertised to MCP servers and links to the relevant issues; no inaccuracies. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant E as Environment (MCP_CLIENT_ROOTS)
    participant CR as client_roots.py
    participant MC as mcp_client.py (module init)
    participant FC as fastmcp.Client
    participant MS as MCP Server (e.g. filesystem)

    MC->>CR: parse_client_roots()
    CR->>E: os.getenv("MCP_CLIENT_ROOTS", "/data")
    E-->>CR: "/data" (or custom paths)
    CR-->>MC: ["/data"]
    MC->>FC: "Client(config, roots=["/data"])"
    Note over FC: converts str to mcp.types.Root(uri=FileUrl)
    MS->>FC: roots/list request
    FC-->>MS: "[Root(uri="file:///data")]"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant E as Environment (MCP_CLIENT_ROOTS)
    participant CR as client_roots.py
    participant MC as mcp_client.py (module init)
    participant FC as fastmcp.Client
    participant MS as MCP Server (e.g. filesystem)

    MC->>CR: parse_client_roots()
    CR->>E: os.getenv("MCP_CLIENT_ROOTS", "/data")
    E-->>CR: "/data" (or custom paths)
    CR-->>MC: ["/data"]
    MC->>FC: "Client(config, roots=["/data"])"
    Note over FC: converts str to mcp.types.Root(uri=FileUrl)
    MS->>FC: roots/list request
    FC-->>MS: "[Root(uri="file:///data")]"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(agent-environment): isolate default..."](https://github.com/scaleapi/mcp-atlas/commit/b30e28022f0f16ba1c6d8dc59b2d2ac33d68a050) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43732807)</sub>

<!-- /greptile_comment -->