### PR TITLE
Bump exa-mcp-server to 3.2.1

### DIFF
--- a/services/agent-environment/dev_scripts/install_mcp_packages.sh
+++ b/services/agent-environment/dev_scripts/install_mcp_packages.sh
@@ -12,7 +12,7 @@ npm install -g \
     @upstash/context7-mcp@1.0.14 \
     @wonderwhy-er/desktop-commander@0.2.7 \
     @e2b/mcp-server@0.2.0 \
-    exa-mcp-server@0.3.10 \
+    exa-mcp-server@3.2.1 \
     @modelcontextprotocol/server-filesystem@2026.7.10 \
     @modelcontextprotocol/server-google-maps@0.6.2 \
     @geobio/google-workspace-server@0.1.0 \

--- a/services/agent-environment/src/agent_environment/mcp_server_template.json
+++ b/services/agent-environment/src/agent_environment/mcp_server_template.json
@@ -93,7 +93,7 @@
     "exa": {
       "command": "npx",
       "args": [
-        "exa-mcp-server@0.3.10"
+        "exa-mcp-server@3.2.1"
       ],
       "env": {
         "EXA_API_KEY": "${EXA_API_KEY}"


### PR DESCRIPTION
Bumps `exa-mcp-server` from 0.3.10 to 3.2.1 in both the MCP server template config and the dev pre-install script, keeping them in sync.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR synchronises the `exa-mcp-server` version pin in both the pre-install script and the MCP server template, bumping from `0.3.10` to `3.2.1`. No structural config changes are needed — the server still consumes only `EXA_API_KEY` and is invoked via `npx`.

- `install_mcp_packages.sh`: single-line version pin update for the global `npm install -g` call.
- `mcp_server_template.json`: matching version pin update in the `args` array for the `exa` server entry; command, env, and all other fields are unchanged.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both files are updated consistently to 3.2.1, the version is published on npm, and the existing env-var-only configuration remains compatible with the new major version.

The change is a two-line version bump kept in sync across the install script and the template. The exa-mcp-server 3.2.1 package is live on npm, the MCP server invocation shape (npx + EXA_API_KEY) is unchanged and still valid for 3.x, and no structural config migration is required.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| services/agent-environment/dev_scripts/install_mcp_packages.sh | Updates exa-mcp-server global npm install from 0.3.10 to 3.2.1; straightforward single-line change, no other modifications. |
| services/agent-environment/src/agent_environment/mcp_server_template.json | Updates the npx version pin for the exa MCP server from 0.3.10 to 3.2.1; env var and command structure remain unchanged and compatible with 3.x. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[install_mcp_packages.sh\nnpm install -g exa-mcp-server@3.2.1] --> B[Global npm cache]
    C[mcp_server_template.json\nnpx exa-mcp-server@3.2.1] --> B
    B --> D[exa-mcp-server 3.2.1\nruntime]
    D --> E[EXA_API_KEY env var]
    E --> F[Exa Search API]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[install_mcp_packages.sh\nnpm install -g exa-mcp-server@3.2.1] --> B[Global npm cache]
    C[mcp_server_template.json\nnpx exa-mcp-server@3.2.1] --> B
    B --> D[exa-mcp-server 3.2.1\nruntime]
    D --> E[EXA_API_KEY env var]
    E --> F[Exa Search API]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump exa-mcp-server to 3.2.1"](https://github.com/scaleapi/mcp-atlas/commit/060865c746801d5f62b89899a91697e4ffcfcf29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45145535)</sub>

<!-- /greptile_comment -->