### PR TITLE
chore: release 1.2.7 image (exa 3.2.1 + mcp-server-git CVE fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for MCP-Atlas
 
 IMAGE_NAME = agent-environment
-VERSION = 1.2.6
+VERSION = 1.2.7
 GHCR_REPO = ghcr.io/scaleapi/mcp-atlas
 
 .PHONY: build run-docker shell push install-harness run-harness install-python run-eval test

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Allocate at least 8 GB (10 GB+ recommended) to Docker.
 
 **Option A — prebuilt image (recommended):**
 ```bash
-docker pull ghcr.io/scaleapi/mcp-atlas:1.2.6
-docker tag ghcr.io/scaleapi/mcp-atlas:1.2.6 agent-environment:latest
+docker pull ghcr.io/scaleapi/mcp-atlas:1.2.7
+docker tag ghcr.io/scaleapi/mcp-atlas:1.2.7 agent-environment:latest
 make run-docker
 ```
 
@@ -78,7 +78,7 @@ curl -X POST http://localhost:3001/v2/mcp_eval/run_agent \
     "model": "openai/gpt-4o",
     "messages": [{"role": "user", "content": "What is the first word of the file at /data/Barber Shop.csv?"}],
     "enabledTools": ["filesystem_read_text_file"],
-    "image": "ghcr.io/scaleapi/mcp-atlas:1.2.6"
+    "image": "ghcr.io/scaleapi/mcp-atlas:1.2.7"
   }' | jq
 ```
 
@@ -109,7 +109,7 @@ Override any default per run:
 | `--timeout S` | `1800` | Per-task timeout, in seconds. |
 | `--num-tasks N` | all | Run only the first N tasks. |
 | `--input PATH` | HuggingFace | Use a local CSV instead of `ScaleAI/MCP-Atlas`. |
-| `--image NAME` | `ghcr.io/scaleapi/mcp-atlas:1.2.6` | Sandbox image. |
+| `--image NAME` | `ghcr.io/scaleapi/mcp-atlas:1.2.7` | Sandbox image. |
 | `--skip-health-check` | off | Skip the pre-flight health check (one real call per server; the run aborts if any server fails). |
 
 - `--extra-llm-params` sets reasoning/provider-specific options, e.g. `--extra-llm-params '{"reasoning_effort": "high"}'` (use whatever key your provider expects; default is the provider's own).
@@ -148,11 +148,11 @@ A single sandbox handles concurrent tasks comfortably, and **you can run several
 
 ```bash
 # Stack A — sandbox on 1984, harness on 3001
-docker run -d -p 1984:1984 --env-file .env ghcr.io/scaleapi/mcp-atlas:1.2.6
+docker run -d -p 1984:1984 --env-file .env ghcr.io/scaleapi/mcp-atlas:1.2.7
 PORT=3001 MCP_SANDBOX_URL=http://localhost:1984 make run-harness
 
 # Stack B — sandbox on 1985, harness on 3002
-docker run -d -p 1985:1984 --env-file .env ghcr.io/scaleapi/mcp-atlas:1.2.6
+docker run -d -p 1985:1984 --env-file .env ghcr.io/scaleapi/mcp-atlas:1.2.7
 PORT=3002 MCP_SANDBOX_URL=http://localhost:1985 make run-harness
 
 # Run each half of the dataset against its own harness, then concatenate

--- a/run_eval.py
+++ b/run_eval.py
@@ -49,7 +49,7 @@ csv.field_size_limit(sys.maxsize)
 HARNESS_URL = os.getenv("HARNESS_URL", "http://localhost:3001")
 SANDBOX_URL = os.getenv("MCP_SANDBOX_URL", "http://localhost:1984")
 DEFAULT_DATASET = "ScaleAI/MCP-Atlas"
-DEFAULT_SANDBOX_IMAGE = "ghcr.io/scaleapi/mcp-atlas:1.2.6"
+DEFAULT_SANDBOX_IMAGE = "ghcr.io/scaleapi/mcp-atlas:1.2.7"
 
 
 def _tool_names(items: list[Any]) -> list[str]:

--- a/services/agent-environment/dev_scripts/install_mcp_packages.sh
+++ b/services/agent-environment/dev_scripts/install_mcp_packages.sh
@@ -35,7 +35,7 @@ uv tool install mcp-server-calculator==0.2.0
 uv tool install cli-mcp-server==0.2.5
 uv tool install duckduckgo-mcp-server==0.5.0
 uv tool install mcp-server-fetch==2025.4.7
-uv tool install mcp-server-git==2025.7.1
+uv tool install mcp-server-git==2026.7.10
 uv tool install osm-mcp-server==0.1.1
 uv tool install oxylabs-mcp==0.4.1
 uv tool install mcp-server-twelve-data==0.2.5

--- a/services/agent-environment/src/agent_environment/mcp_server_template.json
+++ b/services/agent-environment/src/agent_environment/mcp_server_template.json
@@ -115,7 +115,7 @@
     "git": {
       "command": "uvx",
       "args": [
-        "mcp-server-git==2025.7.1"
+        "mcp-server-git==2026.7.10"
       ]
     },
     "github": {


### PR DESCRIPTION
Cuts sandbox image `1.2.7`, bundling two server-pin updates so they ship in one image:

1. **exa-mcp-server 0.3.10 → 3.2.1** (follow-up to #60). `exa_web_search_exa` name/signature unchanged; 3.2.1 additionally exposes `exa_web_fetch_exa` by default.
2. **mcp-server-git 2025.7.1 → 2026.7.10** — security fix for CVE-2025-68143/68144/68145 (supersedes #10; main still pinned the vulnerable 2025.7.1).

## Changes
- `Makefile`: `VERSION` 1.2.6 → 1.2.7
- `run_eval.py`: `DEFAULT_SANDBOX_IMAGE` → `ghcr.io/scaleapi/mcp-atlas:1.2.7`
- `README.md`: all `mcp-atlas:1.2.6` refs → `1.2.7`
- `mcp_server_template.json` + `install_mcp_packages.sh`: exa + git pins (kept in sync; `test_mcp_config_sync.py` passes)

## Why a new tag (not rebuild 1.2.6)
Image tags are mutable; runs pinned to 1.2.6 must stay reproducible, so this ships as a fresh 1.2.7.

## Verification
- Image builds with `exa-mcp-server@3.2.1` + `mcp-server-git==2026.7.10` baked in
- exa: `exa_web_search_exa` returns results (query + numResults — signature unchanged); `exa_web_fetch_exa` works; `test_servers.py --server exa` passes
- git: verified healthy in the rebuilt image via `test_servers.py --server git` (see below)
- `test_mcp_config_sync.py` passes

Multi-arch `ghcr.io/scaleapi/mcp-atlas:1.2.7` + `:latest` built/pushed separately. Merge after the image is confirmed on ghcr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cuts image tag `1.2.7` to ship the `exa-mcp-server@3.2.1` upgrade (from PR #60) into a fresh, reproducible sandbox release. Version references are updated consistently across `Makefile`, `README.md`, and `run_eval.py`.

- **Version bump**: `VERSION` 1.2.6 → 1.2.7 in `Makefile`; all README example commands and `DEFAULT_SANDBOX_IMAGE` in `run_eval.py` updated to match.
- **exa server**: `exa-mcp-server@3.2.1` is already reflected in `mcp_server_template.json` and `install_mcp_packages.sh` (carried over from PR #60).
- **Undocumented addition**: `mcp-server-git` is also bumped (`2025.7.1` → `2026.7.10`) in both `install_mcp_packages.sh` and `mcp_server_template.json`, but is not mentioned in the PR description or verification steps — reviewers should be aware this change is also baked into the 1.2.7 image.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge once the image is confirmed on ghcr.io; all version references are internally consistent.

The change is a straightforward version-string bump across four files, with no logic changes. The only noteworthy detail is an undocumented mcp-server-git upgrade also baked into 1.2.7, which warrants a quick clarification but does not block the merge.

install_mcp_packages.sh and mcp_server_template.json carry the undocumented mcp-server-git bump worth confirming with the author.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | VERSION bumped 1.2.6 → 1.2.7; no logic changes. |
| README.md | All five mcp-atlas:1.2.6 references updated to 1.2.7; documentation only. |
| run_eval.py | DEFAULT_SANDBOX_IMAGE updated to mcp-atlas:1.2.7; single-line version bump. |
| services/agent-environment/dev_scripts/install_mcp_packages.sh | mcp-server-git bumped 2025.7.1 → 2026.7.10; consistent with mcp_server_template.json but not mentioned in the PR description or verification steps. |
| services/agent-environment/src/agent_environment/mcp_server_template.json | git server entry updated to mcp-server-git==2026.7.10; matches install_mcp_packages.sh, exa entry already shows 3.2.1. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #60 - exa-mcp-server 3.2.1] -->|baked into image| B[Build ghcr.io/scaleapi/mcp-atlas:1.2.7]
    C[mcp-server-git 2026.7.10] -->|also baked in| B
    B --> D[Push :1.2.7 + :latest to ghcr.io]
    D --> E[Makefile VERSION=1.2.7]
    D --> F[run_eval.py DEFAULT_SANDBOX_IMAGE=1.2.7]
    D --> G[README.md examples updated to 1.2.7]
    E & F & G --> H[PR #61 merged]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR #60 - exa-mcp-server 3.2.1] -->|baked into image| B[Build ghcr.io/scaleapi/mcp-atlas:1.2.7]
    C[mcp-server-git 2026.7.10] -->|also baked in| B
    B --> D[Push :1.2.7 + :latest to ghcr.io]
    D --> E[Makefile VERSION=1.2.7]
    D --> F[run_eval.py DEFAULT_SANDBOX_IMAGE=1.2.7]
    D --> G[README.md examples updated to 1.2.7]
    E & F & G --> H[PR #61 merged]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: bump mcp-server-git to 2026.7.10 (C..."](https://github.com/scaleapi/mcp-atlas/commit/013ddec9e1a29fa57f7648a86bcb1398e83e8a86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45180940)</sub>

<!-- /greptile_comment -->