### PR TITLE
ci: add pin-sync CI + regression guards for MCP install-script drift

### DIFF
--- a/.github/workflows/agent-environment-tests.yml
+++ b/.github/workflows/agent-environment-tests.yml
@@ -1,0 +1,34 @@
+name: agent-environment tests
+
+# Guards against MCP pin drift: mcp_server_template.json is the source of truth
+# and install_mcp_packages.sh must stay in sync (see services/agent-environment/README.md).
+# Runs the sync + filesystem-pin regression tests on every PR touching those files.
+
+on:
+  pull_request:
+    paths:
+      - "services/agent-environment/src/agent_environment/mcp_server_template.json"
+      - "services/agent-environment/dev_scripts/install_mcp_packages.sh"
+      - "services/agent-environment/tests/**"
+      - ".github/workflows/agent-environment-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "services/agent-environment/src/agent_environment/mcp_server_template.json"
+      - "services/agent-environment/dev_scripts/install_mcp_packages.sh"
+      - "services/agent-environment/tests/**"
+      - ".github/workflows/agent-environment-tests.yml"
+
+jobs:
+  pin-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: Run MCP pin-sync tests
+        working-directory: services/agent-environment
+        run: python -m pytest tests/ -v

--- a/services/agent-environment/README.md
+++ b/services/agent-environment/README.md
@@ -56,10 +56,3 @@ This depends on https://github.com/jlowin/fastmcp
 By default, caching is enabled. If a request is successful, it will be cached, and subsequent identical requests will return the cached value.
 
 At high throughputs, some of the MCP servers may not perform as well or may freeze up. Replicas are recommended for high throughput.
-
-## Pinned MCP server versions
-
-`mcp_server_template.json` is the source of truth for MCP package pins. `dev_scripts/install_mcp_packages.sh` must stay in sync (`pytest tests/test_mcp_config_sync.py`).
-
-The filesystem server must be `@modelcontextprotocol/server-filesystem@2025.12.18` or newer. `@2025.11.25` fails MCP output validation on `directory_tree` (see [issue #34](https://github.com/scaleapi/mcp-atlas/issues/34) and [modelcontextprotocol/servers#3110](https://github.com/modelcontextprotocol/servers/issues/3110)). `tests/test_filesystem_pin.py` enforces the minimum pin.
-

--- a/services/agent-environment/README.md
+++ b/services/agent-environment/README.md
@@ -56,3 +56,10 @@ This depends on https://github.com/jlowin/fastmcp
 By default, caching is enabled. If a request is successful, it will be cached, and subsequent identical requests will return the cached value.
 
 At high throughputs, some of the MCP servers may not perform as well or may freeze up. Replicas are recommended for high throughput.
+
+## Pinned MCP server versions
+
+`mcp_server_template.json` is the source of truth for MCP package pins. `dev_scripts/install_mcp_packages.sh` must stay in sync (`pytest tests/test_mcp_config_sync.py`).
+
+The filesystem server must be `@modelcontextprotocol/server-filesystem@2025.12.18` or newer. `@2025.11.25` fails MCP output validation on `directory_tree` (see [issue #34](https://github.com/scaleapi/mcp-atlas/issues/34) and [modelcontextprotocol/servers#3110](https://github.com/modelcontextprotocol/servers/issues/3110)). `tests/test_filesystem_pin.py` enforces the minimum pin.
+

--- a/services/agent-environment/tests/test_filesystem_pin.py
+++ b/services/agent-environment/tests/test_filesystem_pin.py
@@ -1,0 +1,52 @@
+"""
+Regression guard for scaleapi/mcp-atlas#34.
+
+The filesystem MCP server @2025.11.25 returns structured content for
+directory_tree that fails MCP output validation (-32602). Fixed upstream in
+modelcontextprotocol/servers#3110 (2025.12.18+).
+
+Template is source of truth; install_mcp_packages.sh must stay in sync
+(test_mcp_config_sync.py). This test additionally enforces a minimum pin.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+TEMPLATE = (
+    Path(__file__).parent.parent
+    / "src"
+    / "agent_environment"
+    / "mcp_server_template.json"
+)
+
+# CalVer components — reject pins before the upstream fix shipped.
+MIN_FILESYSTEM_CALVER = (2025, 12, 18)
+
+
+def _parse_calver(version: str) -> tuple[int, ...]:
+    parts = version.split(".")
+    return tuple(int(p) for p in parts)
+
+
+def _filesystem_pin_from_template() -> str:
+    with open(TEMPLATE) as f:
+        data = json.load(f)
+    args = data["mcpServers"]["filesystem"]["args"]
+    for arg in args:
+        if arg.startswith("@modelcontextprotocol/server-filesystem@"):
+            return arg
+    raise AssertionError("filesystem server pin not found in mcp_server_template.json")
+
+
+def test_filesystem_pin_meets_minimum_for_directory_tree():
+    pin = _filesystem_pin_from_template()
+    match = re.search(r"@([\d.]+)$", pin)
+    assert match, f"unexpected filesystem pin format: {pin}"
+    calver = _parse_calver(match.group(1))
+    assert calver >= MIN_FILESYSTEM_CALVER, (
+        f"filesystem pin {pin} is below minimum {MIN_FILESYSTEM_CALVER} "
+        "(directory_tree MCP validation — see #34)"
+    )

--- a/services/agent-environment/tests/test_mcp_config_sync.py
+++ b/services/agent-environment/tests/test_mcp_config_sync.py
@@ -266,6 +266,38 @@ def test_package_sync():
 
         raise AssertionError("\n".join(error_msg))
 
+    # Reverse direction: catch packages left in the script that are no longer
+    # in the template (bloat / stale removals). The template is the source of
+    # truth, so anything the script installs must be justified by it.
+    extra_npx = script_npx_set - config_regular_npx
+    extra_uvx = script_uvx_set - config_regular_uvx
+
+    if extra_npx or extra_uvx:
+        error_msg = [
+            "❌ Install script has packages not present in template "
+            "(template is source of truth):",
+            "",
+        ]
+        if extra_npx:
+            error_msg.append("NPX packages in script but not in template:")
+            error_msg.extend([f"  - {pkg}" for pkg in sorted(extra_npx)])
+            error_msg.append("")
+        if extra_uvx:
+            error_msg.append("UVX packages in script but not in template:")
+            error_msg.extend([f"  - {pkg}" for pkg in sorted(extra_uvx)])
+            error_msg.append("")
+
+        error_msg.extend(
+            [
+                "🔧 TO FIX: Remove the stale packages from "
+                "dev_scripts/install_mcp_packages.sh",
+                "   - Or add them back to mcp_server_template.json if still needed",
+                "   - Template (mcp_server_template.json) is the source of truth",
+            ]
+        )
+
+        raise AssertionError("\n".join(error_msg))
+
     print(
         f"✅ All {len(config_regular_npx)} NPX packages from template are in install script!"
     )


### PR DESCRIPTION
**Credit to @Abhishek21g in #57** 

## Why

The template→install-script pin drift that broke `directory_tree` (#34) shipped to Docker images because **the repo has no CI** — `tests/test_mcp_config_sync.py` existed and *does* catch version mismatches, but nothing ever ran it. A perfect sync test prevents nothing if it isn't wired up.

This closes that gap and hardens the tests, superseding the remainder of #57 (its version bumps already landed via `60ae87d`; template↔script are fully in sync on main today, verified both directions).

## Changes

- **`.github/workflows/agent-environment-tests.yml`** — runs the pin-sync tests on every PR (and push to main) that touches the template, install script, or tests. This is the piece that actually prevents recurrence.
- **`tests/test_filesystem_pin.py`** (from #57) — a minimum-CalVer *floor* for the filesystem pin. The sync test only enforces `script == template`; if both get bumped back to the broken `@2025.11.25` the bug returns silently. This guard rejects anything below the upstream fix (`2025.12.18`). Cleaned up the two Greptile nits (redundant assertion removed, upstream issue ref aligned to `#3110`).
- **`tests/test_mcp_config_sync.py`** — closed a reverse-drift blind spot: the docstring claimed to catch stale packages left in the script, but the code only checked template→script. Now also asserts `script − template` is empty (bloat / stale removals). Verified it fires with a negative test.
- **`README.md`** (from #57) — documents the pin policy.

## Verification

```bash
cd services/agent-environment && python3 -m pytest tests/ -v   # 2 passed
```

Both new guards confirmed to fire on regression (stale-package injection; pin rolled back to 2025.11.25).

## Follow-up

#57 can be closed — its install-script sync already merged, and the useful remainder (test + docs) is carried here rebased and cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up CI for the `agent-environment` service and hardens the existing pin-sync tests to close the gap that let the `directory_tree` regression (#34) reach Docker images undetected.

- **`.github/workflows/agent-environment-tests.yml`**: New workflow runs `pytest tests/` on every PR or push to `main` that touches the template, install script, tests, or the workflow file itself — path filters are tight and correct.
- **`test_filesystem_pin.py`**: Adds a CalVer floor guard (`>= 2025.12.18`) so that even a perfectly-synced template+script pair can't silently regress to the broken `@2025.11.25` pin.
- **`test_mcp_config_sync.py`**: Closes the reverse-drift blind spot by also asserting `script − template = ∅`, preventing stale packages from accumulating in the install script after they're removed from the template.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds CI and test-only files with no changes to production code paths.

All three changed files are either a new GitHub Actions workflow or test code. The reverse-direction sync check is logically correct, and no production code is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/agent-environment-tests.yml | New CI workflow that runs pin-sync tests on PRs and pushes to main touching the template, install script, or tests; path filters are correct and minimal. |
| services/agent-environment/tests/test_filesystem_pin.py | New regression guard enforcing a minimum CalVer floor (2025.12.18) for the filesystem MCP pin; logic is correct and well-scoped. |
| services/agent-environment/tests/test_mcp_config_sync.py | Adds a reverse-direction check (script − template) to catch stale packages left in the install script; set arithmetic and early-exit ordering are correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[PR or push to main] -->|paths filter matches| TRIGGER[Workflow triggered]
    TRIGGER --> CHECKOUT[checkout v4]
    CHECKOUT --> PYSETUP[setup-python 3.12]
    PYSETUP --> INSTALL[pip install pytest]
    INSTALL --> RUN[pytest tests]
    RUN --> T1[test_mcp_config_sync]
    RUN --> T2[test_filesystem_pin]
    T1 --> FWD[Forward: template pkgs present in script]
    FWD -->|missing| FAIL1[AssertionError: missing packages]
    FWD -->|ok| REV[Reverse: script pkgs present in template]
    REV -->|extra| FAIL2[AssertionError: stale packages in script]
    REV -->|ok| PASS1[Sync OK]
    T2 --> READPIN[Read filesystem pin from template json]
    READPIN --> PARSEPIN[Parse CalVer tuple]
    PARSEPIN -->|below 2025.12.18| FAIL3[AssertionError: pin too old]
    PARSEPIN -->|meets minimum| PASS2[Pin OK]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update README.md"](https://github.com/scaleapi/mcp-atlas/commit/5b89522ae8c1bcbeef14eaff416ce3b776155cd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46127352)</sub>

<!-- /greptile_comment -->